### PR TITLE
feat(inference): add reusable optimizer loop with optax

### DIFF
--- a/docs/development/gradient_production_pr_plan.md
+++ b/docs/development/gradient_production_pr_plan.md
@@ -25,10 +25,10 @@ proof-of-concept notebooks to production full-IFU workflows.
 2. `feat(parameterization)` (completed)
 - Add constrained parameter transforms (age/metallicity first) and tests.
 
-3. `refactor(gradient-modes)` (current)
+3. `refactor(gradient-modes)` (completed)
 - Separate deterministic and stochastic (PRNG-keyed) gradient paths.
 
-4. `feat(optimizer-loop)`
+4. `feat(optimizer-loop)` (current)
 - Add reusable Optax optimization loop with histories/checkpoints.
 
 5. `test(gradient-vs-fd)`

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -2,6 +2,7 @@
 
 from .api import apply_params, forward, loss, value_and_grad
 from .modes import get_pipeline_name_for_mode, make_inference_pipeline
+from .optimize import OptimizationResult, optimize_params
 from .parameterization import (
     IdentityTransform,
     ParameterTransform,
@@ -17,6 +18,7 @@ __all__ = [
     "ParameterTransform",
     "SigmoidBounds",
     "SoftplusLowerBound",
+    "OptimizationResult",
     "apply_params",
     "apply_transforms",
     "build_age_metallicity_transforms",
@@ -25,5 +27,6 @@ __all__ = [
     "inverse_transforms",
     "loss",
     "make_inference_pipeline",
+    "optimize_params",
     "value_and_grad",
 ]

--- a/rubix/inference/optimize.py
+++ b/rubix/inference/optimize.py
@@ -81,12 +81,6 @@ def optimize_params(
         )
 
     opt_state = optimizer.init(trainable_params)
-    loss_history: list[float] = []
-    grad_norm_history: list[float] = []
-    best_loss = jnp.inf
-    best_params = trainable_params
-    converged = False
-    steps_run = 0
 
     def train_loss(train_params):
         if transforms is None:
@@ -106,48 +100,76 @@ def optimize_params(
             noise_key=noise_key,
         )
 
-    for step in range(max_steps):
-        value, grads = jax.value_and_grad(train_loss)(trainable_params)
-        updates, opt_state = optimizer.update(grads, opt_state, trainable_params)
-        trainable_params = optax.apply_updates(trainable_params, updates)
+    def scan_step(carry, _):
+        params, opt_state, best_params, best_loss = carry
+        value, grads = jax.value_and_grad(train_loss)(params)
+        param_updates, new_opt_state = optimizer.update(grads, opt_state, params)
+        new_params = optax.apply_updates(params, param_updates)
 
         grad_norm = optax.global_norm(grads)
-        update_norm = optax.global_norm(updates)
+        update_norm = optax.global_norm(param_updates)
 
-        loss_value = float(value)
-        loss_history.append(loss_value)
-        grad_norm_history.append(float(grad_norm))
+        # Track best params on-device without Python-side branching
+        is_better = value < best_loss
+        new_best_loss = jnp.where(is_better, value, best_loss)
+        new_best_params = jax.tree_util.tree_map(
+            lambda new, old: jnp.where(is_better, new, old),
+            new_params,
+            best_params,
+        )
 
-        if value < best_loss:
-            best_loss = value
-            best_params = trainable_params
+        new_carry = (new_params, new_opt_state, new_best_params, new_best_loss)
+        return new_carry, (value, grad_norm, update_norm)
 
-        steps_run = step + 1
-        if float(update_norm) < tol:
-            converged = True
-            break
+    init_carry = (
+        trainable_params,
+        opt_state,
+        trainable_params,
+        jnp.array(float("inf")),
+    )
+    (final_params, _, final_best_params, best_loss_val), (
+        loss_arr,
+        grad_norm_arr,
+        update_norm_arr,
+    ) = jax.lax.scan(scan_step, init_carry, None, length=max_steps)
+
+    # Detect convergence post-hoc; no device->host sync until here
+    converged_mask = update_norm_arr < tol
+    converged = bool(jnp.any(converged_mask))
+    if converged:
+        steps_run = int(jnp.argmax(converged_mask)) + 1
+    else:
+        steps_run = max_steps
+
+    # Materialize history once at the end
+    loss_history: list[float] = loss_arr[:steps_run].tolist()
+    grad_norm_history: list[float] = grad_norm_arr[:steps_run].tolist()
 
     if transforms is None:
-        final_params = trainable_params
-        final_best_params = best_params
+        result_params = _tree_to_dict(final_params)
+        result_best_params = _tree_to_dict(final_best_params)
     else:
-        final_params = apply_transforms(
-            params=trainable_params,
-            transforms=transforms,
-            direction="forward",
+        result_params = _tree_to_dict(
+            apply_transforms(
+                params=final_params,
+                transforms=transforms,
+                direction="forward",
+            )
         )
-        final_best_params = apply_transforms(
-            params=best_params,
-            transforms=transforms,
-            direction="forward",
+        result_best_params = _tree_to_dict(
+            apply_transforms(
+                params=final_best_params,
+                transforms=transforms,
+                direction="forward",
+            )
         )
 
     return OptimizationResult(
-        params=_tree_to_dict(final_params),
-        best_params=_tree_to_dict(final_best_params),
+        params=result_params,
+        best_params=result_best_params,
         loss_history=loss_history,
         grad_norm_history=grad_norm_history,
-        best_loss=float(best_loss),
+        best_loss=float(best_loss_val),
         steps_run=steps_run,
         converged=converged,
     )

--- a/rubix/inference/optimize.py
+++ b/rubix/inference/optimize.py
@@ -125,7 +125,7 @@ def optimize_params(
         trainable_params,
         opt_state,
         trainable_params,
-        jnp.array(float("inf")),
+        jnp.array(jnp.inf),
     )
     (final_params, _, final_best_params, best_loss_val), (
         loss_arr,
@@ -133,13 +133,12 @@ def optimize_params(
         update_norm_arr,
     ) = jax.lax.scan(scan_step, init_carry, None, length=max_steps)
 
-    # Detect convergence post-hoc; no device->host sync until here
+    # Detect convergence post-hoc; no device->host sync until here.
+    # argmax over a boolean array returns the index of the first True; the
+    # `converged` guard ensures it is only used when at least one True exists.
     converged_mask = update_norm_arr < tol
     converged = bool(jnp.any(converged_mask))
-    if converged:
-        steps_run = int(jnp.argmax(converged_mask)) + 1
-    else:
-        steps_run = max_steps
+    steps_run = (int(jnp.argmax(converged_mask)) + 1) if converged else max_steps
 
     # Materialize history once at the end
     loss_history: list[float] = loss_arr[:steps_run].tolist()

--- a/rubix/inference/optimize.py
+++ b/rubix/inference/optimize.py
@@ -6,6 +6,8 @@ import jax.numpy as jnp
 import optax
 from beartype.typing import Any
 
+from rubix.core.data import RubixData
+
 from .api import LossFn, loss
 from .parameterization import TransformTree, apply_transforms
 
@@ -33,7 +35,7 @@ def _tree_to_dict(tree: ParamsTree) -> dict[str, dict[str, Any]]:
 def optimize_params(
     pipeline: Any,
     params_init: ParamsTree,
-    static_data: Any,
+    static_data: RubixData,
     target: jnp.ndarray,
     learning_rate: float = 1e-3,
     max_steps: int = 500,
@@ -48,7 +50,7 @@ def optimize_params(
     Args:
         pipeline (Any): Pipeline-like object consumed by :func:`rubix.inference.loss`.
         params_init (ParamsTree): Initial parameters in constrained space.
-        static_data (Any): Baseline RubixData passed to the forward model.
+        static_data (RubixData): Baseline RubixData passed to the forward model.
         target (jnp.ndarray): Target datacube or statistic.
         learning_rate (float, optional): Step size for default Adam optimizer.
             Defaults to 1e-3.

--- a/rubix/inference/optimize.py
+++ b/rubix/inference/optimize.py
@@ -4,7 +4,7 @@ from typing import Mapping, Optional
 import jax
 import jax.numpy as jnp
 import optax
-from beartype.typing import Any, Callable
+from beartype.typing import Any
 
 from .api import LossFn, loss
 from .parameterization import TransformTree, apply_transforms

--- a/rubix/inference/optimize.py
+++ b/rubix/inference/optimize.py
@@ -1,0 +1,153 @@
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+import jax
+import jax.numpy as jnp
+import optax
+from beartype.typing import Any, Callable
+
+from .api import LossFn, loss
+from .parameterization import TransformTree, apply_transforms
+
+ParamsTree = Mapping[str, Mapping[str, Any]]
+
+
+@dataclass
+class OptimizationResult:
+    """Container for optimization outputs."""
+
+    params: dict[str, dict[str, Any]]
+    best_params: dict[str, dict[str, Any]]
+    loss_history: list[float]
+    grad_norm_history: list[float]
+    best_loss: float
+    steps_run: int
+    converged: bool
+
+
+def _tree_to_dict(tree: ParamsTree) -> dict[str, dict[str, Any]]:
+    """Return a mutable dictionary copy from a nested parameter tree."""
+    return {component: dict(fields) for component, fields in tree.items()}
+
+
+def optimize_params(
+    pipeline: Any,
+    params_init: ParamsTree,
+    static_data: Any,
+    target: jnp.ndarray,
+    learning_rate: float = 1e-3,
+    max_steps: int = 500,
+    tol: float = 1e-6,
+    loss_fn: Optional[LossFn] = None,
+    noise_key: Optional[jnp.ndarray] = None,
+    transforms: Optional[TransformTree] = None,
+    optimizer: Optional[optax.GradientTransformation] = None,
+) -> OptimizationResult:
+    """Run gradient-based parameter optimization with Optax.
+
+    Args:
+        pipeline (Any): Pipeline-like object consumed by :func:`rubix.inference.loss`.
+        params_init (ParamsTree): Initial parameters in constrained space.
+        static_data (Any): Baseline RubixData passed to the forward model.
+        target (jnp.ndarray): Target datacube or statistic.
+        learning_rate (float, optional): Step size for default Adam optimizer.
+            Defaults to 1e-3.
+        max_steps (int, optional): Maximum optimization steps. Defaults to 500.
+        tol (float, optional): Convergence threshold on global update norm.
+            Defaults to 1e-6.
+        loss_fn (Optional[LossFn], optional): Optional custom loss function.
+            Defaults to ``None`` (sum-of-squares).
+        noise_key (Optional[jnp.ndarray], optional): Optional key for stochastic
+            pipelines. Defaults to ``None``.
+        transforms (Optional[TransformTree], optional): Optional transform tree
+            that maps unconstrained parameters to constrained parameters.
+            Defaults to ``None``.
+        optimizer (Optional[optax.GradientTransformation], optional): Custom
+            Optax optimizer. Defaults to ``None`` (Adam with ``learning_rate``).
+
+    Returns:
+        OptimizationResult: Final/best params and optimization traces.
+    """
+    if optimizer is None:
+        optimizer = optax.adam(learning_rate)
+
+    if transforms is None:
+        trainable_params = _tree_to_dict(params_init)
+    else:
+        trainable_params = apply_transforms(
+            params=params_init,
+            transforms=transforms,
+            direction="inverse",
+        )
+
+    opt_state = optimizer.init(trainable_params)
+    loss_history: list[float] = []
+    grad_norm_history: list[float] = []
+    best_loss = jnp.inf
+    best_params = trainable_params
+    converged = False
+    steps_run = 0
+
+    def train_loss(train_params):
+        if transforms is None:
+            constrained_params = train_params
+        else:
+            constrained_params = apply_transforms(
+                params=train_params,
+                transforms=transforms,
+                direction="forward",
+            )
+        return loss(
+            pipeline=pipeline,
+            params=constrained_params,
+            static_data=static_data,
+            target=target,
+            loss_fn=loss_fn,
+            noise_key=noise_key,
+        )
+
+    for step in range(max_steps):
+        value, grads = jax.value_and_grad(train_loss)(trainable_params)
+        updates, opt_state = optimizer.update(grads, opt_state, trainable_params)
+        trainable_params = optax.apply_updates(trainable_params, updates)
+
+        grad_norm = optax.global_norm(grads)
+        update_norm = optax.global_norm(updates)
+
+        loss_value = float(value)
+        loss_history.append(loss_value)
+        grad_norm_history.append(float(grad_norm))
+
+        if value < best_loss:
+            best_loss = value
+            best_params = trainable_params
+
+        steps_run = step + 1
+        if float(update_norm) < tol:
+            converged = True
+            break
+
+    if transforms is None:
+        final_params = trainable_params
+        final_best_params = best_params
+    else:
+        final_params = apply_transforms(
+            params=trainable_params,
+            transforms=transforms,
+            direction="forward",
+        )
+        final_best_params = apply_transforms(
+            params=best_params,
+            transforms=transforms,
+            direction="forward",
+        )
+
+    return OptimizationResult(
+        params=_tree_to_dict(final_params),
+        best_params=_tree_to_dict(final_best_params),
+        loss_history=loss_history,
+        grad_norm_history=grad_norm_history,
+        best_loss=float(best_loss),
+        steps_run=steps_run,
+        converged=converged,
+    )

--- a/tests/test_inference_optimize.py
+++ b/tests/test_inference_optimize.py
@@ -1,0 +1,107 @@
+import jax.numpy as jnp
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import build_age_metallicity_transforms, optimize_params
+
+
+class DummyPipeline:
+    """Simple differentiable pipeline used for optimizer tests."""
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        age_sum = jnp.sum(rubixdata.stars.age)
+        metallicity_sum = jnp.sum(rubixdata.stars.metallicity)
+        value = age_sum + 2.0 * metallicity_sum
+        return jnp.reshape(value, (1, 1, 1))
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([1.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_optimize_params_reduces_loss_without_transforms():
+    pipeline = DummyPipeline()
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.0]), "metallicity": jnp.array([0.0])}}
+    target = jnp.array([[[5.0]]])
+
+    result = optimize_params(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=0.1,
+        max_steps=250,
+        tol=1e-9,
+    )
+
+    assert result.loss_history[0] > result.loss_history[-1]
+    assert result.steps_run <= 250
+    assert result.best_loss <= result.loss_history[-1]
+
+    prediction = pipeline.run_sharded(
+        RubixData(
+            galaxy=static_data.galaxy,
+            stars=StarsData(
+                coords=static_data.stars.coords,
+                velocity=static_data.stars.velocity,
+                mass=static_data.stars.mass,
+                age=result.params["stars"]["age"],
+                metallicity=result.params["stars"]["metallicity"],
+            ),
+            gas=static_data.gas,
+        )
+    )
+    assert jnp.allclose(prediction, target, atol=2e-2, rtol=0.0)
+
+
+def test_optimize_params_with_transforms_respects_bounds_and_converges():
+    pipeline = DummyPipeline()
+    static_data = _make_rubix_data()
+    params_init = {
+        "stars": {
+            "age": jnp.array([0.5]),
+            "metallicity": jnp.array([0.001]),
+        }
+    }
+    transforms = build_age_metallicity_transforms(
+        age_lower=0.0,
+        age_upper=20.0,
+        metallicity_lower=0.0,
+        metallicity_upper=0.05,
+    )
+    target = jnp.array([[[7.04]]])  # 7.0 + 2 * 0.02
+
+    result = optimize_params(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=0.15,
+        max_steps=300,
+        tol=1e-9,
+        transforms=transforms,
+    )
+
+    final_age = result.params["stars"]["age"]
+    final_metallicity = result.params["stars"]["metallicity"]
+
+    assert jnp.all(final_age > 0.0)
+    assert jnp.all(final_age < 20.0)
+    assert jnp.all(final_metallicity > 0.0)
+    assert jnp.all(final_metallicity < 0.05)
+    assert result.loss_history[0] > result.loss_history[-1]
+    assert len(result.grad_norm_history) == len(result.loss_history)


### PR DESCRIPTION
## Summary
- add reusable optimizer loop (optimize_params) for inference workflows
- support optional constrained-parameter transforms during optimization
- return structured optimization traces and best-parameter snapshots
- add unit tests for loss reduction and bounded-transform optimization

## Stack position
PR 4 / 8 in the gradient-production plan