### PR TITLE
refactor(inference): add deterministic/stochastic gradient modes

### DIFF
--- a/docs/development/gradient_production_pr_plan.md
+++ b/docs/development/gradient_production_pr_plan.md
@@ -22,10 +22,10 @@ proof-of-concept notebooks to production full-IFU workflows.
 - Add unit tests for copy semantics, deterministic loss calls, and analytical
   gradient checks.
 
-2. `feat(parameterization)` (current)
+2. `feat(parameterization)` (completed)
 - Add constrained parameter transforms (age/metallicity first) and tests.
 
-3. `refactor(gradient-modes)`
+3. `refactor(gradient-modes)` (current)
 - Separate deterministic and stochastic (PRNG-keyed) gradient paths.
 
 4. `feat(optimizer-loop)`

--- a/rubix/config/pipeline_config.yml
+++ b/rubix/config/pipeline_config.yml
@@ -111,3 +111,64 @@ calc_gradient:
       depends_on: convolve_lsf
       args: []
       kwargs: {}
+
+calc_gradient_deterministic:
+  Transformers:
+    rotate_galaxy:
+      name: rotate_galaxy
+      depends_on: null
+      args: []
+      kwargs: {}
+    spaxel_assignment:
+      name: spaxel_assignment
+      depends_on: rotate_galaxy
+      args: []
+      kwargs: {}
+    calculate_datacube_particlewise:
+      name: calculate_datacube_particlewise
+      depends_on: spaxel_assignment
+      args: []
+      kwargs: {}
+    convolve_psf:
+      name: convolve_psf
+      depends_on: calculate_datacube_particlewise
+      args: []
+      kwargs: {}
+    convolve_lsf:
+      name: convolve_lsf
+      depends_on: convolve_psf
+      args: []
+      kwargs: {}
+
+calc_gradient_stochastic:
+  Transformers:
+    rotate_galaxy:
+      name: rotate_galaxy
+      depends_on: null
+      args: []
+      kwargs: {}
+    spaxel_assignment:
+      name: spaxel_assignment
+      depends_on: rotate_galaxy
+      args: []
+      kwargs: {}
+    calculate_datacube_particlewise:
+      name: calculate_datacube_particlewise
+      depends_on: spaxel_assignment
+      args: []
+      kwargs: {}
+    convolve_psf:
+      name: convolve_psf
+      depends_on: calculate_datacube_particlewise
+      args: []
+      kwargs: {}
+    convolve_lsf:
+      name: convolve_lsf
+      depends_on: convolve_psf
+      args: []
+      kwargs: {}
+    apply_noise:
+      name: apply_noise
+      depends_on: convolve_lsf
+      args: []
+      kwargs: {}

--- a/rubix/config/pipeline_config.yml
+++ b/rubix/config/pipeline_config.yml
@@ -167,8 +167,3 @@ calc_gradient_stochastic:
       depends_on: convolve_psf
       args: []
       kwargs: {}
-    apply_noise:
-      name: apply_noise
-      depends_on: convolve_lsf
-      args: []
-      kwargs: {}

--- a/rubix/core/data.py
+++ b/rubix/core/data.py
@@ -223,11 +223,14 @@ class RubixData:
         galaxy (Optional[Galaxy]): Galaxy metadata.
         stars (Optional[StarsData]): Stellar part data.
         gas (Optional[GasData]): Gas part data.
+        noise_key (Optional[Any]): Optional JAX PRNG key used by stochastic
+            pipeline elements such as noise injection.
     """
 
     galaxy: Optional[Galaxy] = None
     stars: Optional[StarsData] = None
     gas: Optional[GasData] = None
+    noise_key: Optional[Any] = None
 
     def __repr__(self):
         representationString = ["RubixData:"]
@@ -237,7 +240,7 @@ class RubixData:
 
     def tree_flatten(self):
         """Flatten the RubixData object into children and aux data."""
-        children = (self.galaxy, self.stars, self.gas)
+        children = (self.galaxy, self.stars, self.gas, self.noise_key)
         aux_data = {}
         return children, aux_data
 

--- a/rubix/core/noise.py
+++ b/rubix/core/noise.py
@@ -1,6 +1,5 @@
-import jax.numpy as jnp
 from beartype import beartype as typechecker
-from beartype.typing import Callable
+from beartype.typing import Callable, Optional
 from jaxtyping import jaxtyped
 
 from rubix.logger import get_logger
@@ -69,14 +68,12 @@ def get_apply_noise(config: dict) -> Callable[[RubixData], RubixData]:
             f"{signal_to_noise} and noise distribution: {noise_distribution}"
         )
         datacube = rubixdata.stars.datacube
-        # Define S2n for each spaxel
-        S2N = jnp.ones(datacube.shape[:2]) * signal_to_noise
 
         # Calculate the noise cube
         noise_key = rubixdata.noise_key
         noise_cube = calculate_noise_cube(
             datacube,
-            S2N,
+            signal_to_noise,
             noise_distribution=noise_distribution,
             key=noise_key,
         )
@@ -86,3 +83,46 @@ def get_apply_noise(config: dict) -> Callable[[RubixData], RubixData]:
         return rubixdata
 
     return apply_noise
+
+
+def build_post_aggregation_noise_fn(
+    config: dict,
+) -> Optional[Callable]:
+    """Return a callable that adds noise to a raw datacube, or ``None``.
+
+    This is used by :py:class:`~rubix.core.pipeline.RubixPipeline` in
+    stochastic mode to apply noise *once* to the fully aggregated cube after
+    the cross-device reduction, avoiding the incorrect noise statistics that
+    arise when noise is applied independently on each shard before the psum.
+
+    Args:
+        config (dict): Standard Rubix configuration dictionary.  Noise is
+            configured under ``config["telescope"]["noise"]``.
+
+    Returns:
+        Callable[[cube, key], cube] if noise is configured, else ``None``.
+    """
+    noise_cfg = config.get("telescope", {}).get("noise", {})
+    signal_to_noise = noise_cfg.get("signal_to_noise")
+    noise_distribution = noise_cfg.get("noise_distribution", "normal")
+
+    if signal_to_noise is None:
+        return None
+
+    logger = get_logger()
+
+    def _apply(cube, key):
+        logger.info(
+            "Applying post-aggregation noise (S/N=%s, dist=%s).",
+            signal_to_noise,
+            noise_distribution,
+        )
+        noise_cube = calculate_noise_cube(
+            cube,
+            signal_to_noise,
+            noise_distribution=noise_distribution,
+            key=key,
+        )
+        return cube + noise_cube
+
+    return _apply

--- a/rubix/core/noise.py
+++ b/rubix/core/noise.py
@@ -73,8 +73,12 @@ def get_apply_noise(config: dict) -> Callable[[RubixData], RubixData]:
         S2N = jnp.ones(datacube.shape[:2]) * signal_to_noise
 
         # Calculate the noise cube
+        noise_key = rubixdata.noise_key
         noise_cube = calculate_noise_cube(
-            datacube, S2N, noise_distribution=noise_distribution
+            datacube,
+            S2N,
+            noise_distribution=noise_distribution,
+            key=noise_key,
         )
 
         # Add noise to the datacube

--- a/rubix/core/noise.py
+++ b/rubix/core/noise.py
@@ -1,5 +1,5 @@
 from beartype import beartype as typechecker
-from beartype.typing import Callable, Optional
+from beartype.typing import Any, Callable, Optional
 from jaxtyping import jaxtyped
 
 from rubix.logger import get_logger
@@ -87,7 +87,7 @@ def get_apply_noise(config: dict) -> Callable[[RubixData], RubixData]:
 
 def build_post_aggregation_noise_fn(
     config: dict,
-) -> Optional[Callable]:
+) -> Optional[Callable[[Any, Any], Any]]:
     """Return a callable that adds noise to a raw datacube, or ``None``.
 
     This is used by :py:class:`~rubix.core.pipeline.RubixPipeline` in

--- a/rubix/core/pipeline.py
+++ b/rubix/core/pipeline.py
@@ -33,7 +33,7 @@ from .ifu import (
     get_calculate_dusty_datacube_particlewise,
 )
 from .lsf import get_convolve_lsf
-from .noise import get_apply_noise
+from .noise import get_apply_noise, build_post_aggregation_noise_fn
 from .psf import get_convolve_psf
 from .rotation import get_galaxy_rotation
 from .ssp import get_ssp
@@ -46,6 +46,12 @@ class RubixPipeline:
     Args:
         user_config (Union[dict, str]):
             Parsed configuration dictionary or path to a configuration file.
+        apply_noise_post_aggregation (bool):
+            When ``True``, noise is applied *once* to the fully aggregated
+            datacube after the cross-device psum in :py:meth:`run_sharded`,
+            rather than inside each shard.  Set by
+            :py:func:`~rubix.inference.modes.make_inference_pipeline` for
+            stochastic gradient mode.  Defaults to ``False``.
 
     Example:
 
@@ -61,7 +67,11 @@ class RubixPipeline:
             >>> gradient_data = pipe.gradient(inputdata, target_datacube)
     """
 
-    def __init__(self, user_config: Union[dict, str]):
+    def __init__(
+        self,
+        user_config: Union[dict, str],
+        apply_noise_post_aggregation: bool = False,
+    ):
         self.user_config = get_config(user_config)
         pipeline_name = self.user_config["pipeline"]["name"]
         self.pipeline_config = get_pipeline_config(pipeline_name)
@@ -69,6 +79,12 @@ class RubixPipeline:
         self.ssp = get_ssp(self.user_config)
         self.telescope = get_telescope(self.user_config)
         self.func = None
+        self._apply_noise_post_aggregation = apply_noise_post_aggregation
+        self._post_noise_fn = (
+            build_post_aggregation_noise_fn(self.user_config)
+            if apply_noise_post_aggregation
+            else None
+        )
 
     def prepare_data(self):
         """
@@ -257,6 +273,9 @@ class RubixPipeline:
         if inputdata.noise_key is None:
             inputdata.noise_key = jax.random.PRNGKey(0)
 
+        # Capture noise_key before device_put for post-aggregation use
+        noise_key_for_post = inputdata.noise_key
+
         inputdata = jax.device_put(inputdata, rubix_spec)
 
         # create the sharded data
@@ -276,6 +295,12 @@ class RubixPipeline:
         )
 
         sharded_result = sharded_pipeline(inputdata)
+
+        # Apply noise once to the fully aggregated cube (stochastic mode only).
+        # This avoids the incorrect noise-scaling that would result from applying
+        # noise inside each shard before the cross-device psum.
+        if self._post_noise_fn is not None:
+            sharded_result = self._post_noise_fn(sharded_result, noise_key_for_post)
 
         time_end = time.time()
         self.logger.info(

--- a/rubix/core/pipeline.py
+++ b/rubix/core/pipeline.py
@@ -234,6 +234,7 @@ class RubixPipeline:
         rubix_spec.galaxy = galaxy_spec
         rubix_spec.stars = stars_spec
         rubix_spec.gas = gas_spec
+        rubix_spec.noise_key = replicate_1d
 
         # 1) Make a pytree of PartitionSpec
         partition_spec_tree = tree_map(
@@ -252,6 +253,9 @@ class RubixPipeline:
                 num_devices,
             )
             inputdata = _pad_particles(inputdata, pad)
+
+        if inputdata.noise_key is None:
+            inputdata.noise_key = jax.random.PRNGKey(0)
 
         inputdata = jax.device_put(inputdata, rubix_spec)
 

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -1,6 +1,7 @@
 """Inference helpers for gradient-based modeling workflows."""
 
 from .api import apply_params, forward, loss, value_and_grad
+from .modes import get_pipeline_name_for_mode, make_inference_pipeline
 from .parameterization import (
     IdentityTransform,
     ParameterTransform,
@@ -20,7 +21,9 @@ __all__ = [
     "apply_transforms",
     "build_age_metallicity_transforms",
     "forward",
+    "get_pipeline_name_for_mode",
     "inverse_transforms",
     "loss",
+    "make_inference_pipeline",
     "value_and_grad",
 ]

--- a/rubix/inference/api.py
+++ b/rubix/inference/api.py
@@ -76,6 +76,7 @@ def forward(
     pipeline: Any,
     params: ParamsTree,
     static_data: RubixData,
+    noise_key: Optional[jnp.ndarray] = None,
 ) -> jnp.ndarray:
     """Run the Rubix forward model with updated parameters.
 
@@ -83,11 +84,14 @@ def forward(
         pipeline (Any): Object exposing ``run_sharded(RubixData)``.
         params (ParamsTree): Parameter updates applied to ``static_data``.
         static_data (RubixData): Baseline particle data.
+        noise_key (Optional[jnp.ndarray], optional): Optional PRNG key used by
+            stochastic pipeline elements.
 
     Returns:
         jnp.ndarray: Predicted IFU datacube.
     """
     model_input = apply_params(static_data, params)
+    model_input.noise_key = noise_key
     return pipeline.run_sharded(model_input)
 
 
@@ -97,9 +101,15 @@ def loss(
     static_data: RubixData,
     target: jnp.ndarray,
     loss_fn: Optional[LossFn] = None,
+    noise_key: Optional[jnp.ndarray] = None,
 ) -> jnp.ndarray:
     """Compute a scalar loss between predicted and target datacubes."""
-    prediction = forward(pipeline=pipeline, params=params, static_data=static_data)
+    prediction = forward(
+        pipeline=pipeline,
+        params=params,
+        static_data=static_data,
+        noise_key=noise_key,
+    )
     if loss_fn is None:
         return jnp.sum((prediction - target) ** 2)
     return loss_fn(prediction, target)
@@ -111,6 +121,7 @@ def value_and_grad(
     static_data: RubixData,
     target: jnp.ndarray,
     loss_fn: Optional[LossFn] = None,
+    noise_key: Optional[jnp.ndarray] = None,
 ):
     """Return loss value and gradient with respect to ``params``."""
 
@@ -121,6 +132,7 @@ def value_and_grad(
             static_data=static_data,
             target=target,
             loss_fn=loss_fn,
+            noise_key=noise_key,
         )
 
     return jax.value_and_grad(_loss_fn)(params)

--- a/rubix/inference/modes.py
+++ b/rubix/inference/modes.py
@@ -1,0 +1,52 @@
+from copy import deepcopy
+from typing import Literal
+
+from rubix.core.pipeline import RubixPipeline
+
+InferenceMode = Literal["deterministic", "stochastic"]
+
+_PIPELINE_BY_MODE = {
+    "calc_gradient": {
+        "deterministic": "calc_gradient_deterministic",
+        "stochastic": "calc_gradient_stochastic",
+    }
+}
+
+
+def get_pipeline_name_for_mode(
+    pipeline_name: str,
+    mode: InferenceMode,
+) -> str:
+    """Resolve a concrete pipeline name for the requested inference mode.
+
+    Args:
+        pipeline_name (str): Base pipeline name from the user configuration.
+        mode (InferenceMode): Requested inference mode.
+
+    Raises:
+        ValueError: If ``mode`` is invalid.
+
+    Returns:
+        str: Concrete pipeline name for the selected mode.
+    """
+    if mode not in {"deterministic", "stochastic"}:
+        raise ValueError("mode must be one of {'deterministic', 'stochastic'}")
+
+    mapping = _PIPELINE_BY_MODE.get(pipeline_name, {})
+    return mapping.get(mode, pipeline_name)
+
+
+def make_inference_pipeline(user_config: dict, mode: InferenceMode) -> RubixPipeline:
+    """Build a RubixPipeline configured for deterministic or stochastic inference.
+
+    Args:
+        user_config (dict): Standard Rubix configuration dictionary.
+        mode (InferenceMode): Inference mode selector.
+
+    Returns:
+        RubixPipeline: Pipeline instance using mode-specific pipeline graph.
+    """
+    config_copy = deepcopy(user_config)
+    base_name = config_copy["pipeline"]["name"]
+    config_copy["pipeline"]["name"] = get_pipeline_name_for_mode(base_name, mode)
+    return RubixPipeline(config_copy)

--- a/rubix/inference/modes.py
+++ b/rubix/inference/modes.py
@@ -45,8 +45,14 @@ def make_inference_pipeline(user_config: dict, mode: InferenceMode) -> RubixPipe
 
     Returns:
         RubixPipeline: Pipeline instance using mode-specific pipeline graph.
+
+    Note:
+        In stochastic mode, ``apply_noise`` is intentionally excluded from the
+        sharded pipeline graph.  Instead, noise is applied once to the fully
+        aggregated datacube after the cross-device reduction, which avoids
+        incorrect noise statistics caused by summing independently-noised shards.
     """
     config_copy = deepcopy(user_config)
     base_name = config_copy["pipeline"]["name"]
     config_copy["pipeline"]["name"] = get_pipeline_name_for_mode(base_name, mode)
-    return RubixPipeline(config_copy)
+    return RubixPipeline(config_copy, apply_noise_post_aggregation=(mode == "stochastic"))

--- a/rubix/telescope/noise/noise.py
+++ b/rubix/telescope/noise/noise.py
@@ -77,6 +77,7 @@ def calculate_noise_cube(
     cube: Float[Array, "n_x n_y n_wave_bins"],
     signal_to_noise: float,
     noise_distribution: str = "normal",
+    key: Optional[jnp.ndarray] = None,
 ) -> Float[Array, "n_x n_y n_wave_bins"]:
     """Calculate the noise cube given the cube and the signal-to-noise ratio.
 
@@ -86,11 +87,14 @@ def calculate_noise_cube(
         cube (Float[Array, "n_x n_y n_wave_bins"]): The data cube.
         signal_to_noise (float): The signal-to-noise ratio of the observation.
         noise_distribution (str, optional): The type of distribution to sample from. Can be either "normal" or "uniform". Defaults to "normal".
+        key (Optional[jnp.ndarray], optional): JAX random key used to sample
+            noise. If ``None``, a fixed key is used for reproducibility.
 
     Returns:
         Float[Array, "n_x n_y n_wave_bins"]: The noise cube.
     """
-    key = jrandom.PRNGKey(0)
+    if key is None:
+        key = jrandom.PRNGKey(0)
     # S2N = jnp.where(
     #     jnp.isinf(S2N), 0, S2N
     # )  # removing infinite noise where particles per pixel = 0

--- a/tests/test_inference_api.py
+++ b/tests/test_inference_api.py
@@ -2,7 +2,7 @@ import jax.numpy as jnp
 import pytest
 
 from rubix.core.data import Galaxy, GasData, RubixData, StarsData
-from rubix.inference import apply_params, loss, value_and_grad
+from rubix.inference import apply_params, forward, loss, value_and_grad
 
 
 class DummyPipeline:
@@ -13,6 +13,17 @@ class DummyPipeline:
         metallicity_sum = jnp.sum(rubixdata.stars.metallicity)
         value = age_sum + 2.0 * metallicity_sum
         return jnp.reshape(value, (1, 1, 1))
+
+
+class DummyPipelineWithNoiseCapture:
+    """Dummy pipeline capturing the propagated noise key."""
+
+    def __init__(self):
+        self.seen_noise_key = None
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        self.seen_noise_key = rubixdata.noise_key
+        return jnp.zeros((1, 1, 1))
 
 
 def _make_rubix_data() -> RubixData:
@@ -87,3 +98,20 @@ def test_value_and_grad_matches_analytic_gradient():
     assert jnp.allclose(value, residual**2)
     assert jnp.allclose(grads["stars"]["age"], expected_grad_age)
     assert jnp.allclose(grads["stars"]["metallicity"], expected_grad_metallicity)
+
+
+def test_forward_propagates_noise_key():
+    pipeline = DummyPipelineWithNoiseCapture()
+    static_data = _make_rubix_data()
+    params = {"stars": {"age": jnp.array([1.0, 1.0])}}
+    noise_key = jnp.array([17, 42], dtype=jnp.uint32)
+
+    _ = forward(
+        pipeline=pipeline,
+        params=params,
+        static_data=static_data,
+        noise_key=noise_key,
+    )
+
+    assert pipeline.seen_noise_key is not None
+    assert jnp.array_equal(pipeline.seen_noise_key, noise_key)

--- a/tests/test_inference_modes.py
+++ b/tests/test_inference_modes.py
@@ -1,6 +1,8 @@
 import pytest
+from unittest.mock import patch, MagicMock
 
 from rubix.inference import get_pipeline_name_for_mode
+from rubix.inference.modes import make_inference_pipeline
 
 
 def test_get_pipeline_name_for_mode_gradient_modes():
@@ -19,3 +21,27 @@ def test_get_pipeline_name_for_mode_passthrough_for_unknown_pipeline():
 def test_get_pipeline_name_for_mode_rejects_invalid_mode():
     with pytest.raises(ValueError, match="mode must be one of"):
         get_pipeline_name_for_mode("calc_gradient", "bad")  # type: ignore[arg-type]
+
+
+def test_make_inference_pipeline_sets_post_aggregation_noise_for_stochastic():
+    dummy_config = {"pipeline": {"name": "calc_gradient"}}
+    mock_pipeline = MagicMock()
+    mock_pipeline._apply_noise_post_aggregation = False
+
+    with patch("rubix.inference.modes.RubixPipeline") as MockRubixPipeline:
+        MockRubixPipeline.return_value = mock_pipeline
+        make_inference_pipeline(dummy_config, "stochastic")
+        _, kwargs = MockRubixPipeline.call_args
+        assert kwargs.get("apply_noise_post_aggregation") is True
+
+
+def test_make_inference_pipeline_does_not_set_post_aggregation_noise_for_deterministic():
+    dummy_config = {"pipeline": {"name": "calc_gradient"}}
+    mock_pipeline = MagicMock()
+    mock_pipeline._apply_noise_post_aggregation = False
+
+    with patch("rubix.inference.modes.RubixPipeline") as MockRubixPipeline:
+        MockRubixPipeline.return_value = mock_pipeline
+        make_inference_pipeline(dummy_config, "deterministic")
+        _, kwargs = MockRubixPipeline.call_args
+        assert kwargs.get("apply_noise_post_aggregation") is False

--- a/tests/test_inference_modes.py
+++ b/tests/test_inference_modes.py
@@ -25,11 +25,9 @@ def test_get_pipeline_name_for_mode_rejects_invalid_mode():
 
 def test_make_inference_pipeline_sets_post_aggregation_noise_for_stochastic():
     dummy_config = {"pipeline": {"name": "calc_gradient"}}
-    mock_pipeline = MagicMock()
-    mock_pipeline._apply_noise_post_aggregation = False
 
     with patch("rubix.inference.modes.RubixPipeline") as MockRubixPipeline:
-        MockRubixPipeline.return_value = mock_pipeline
+        MockRubixPipeline.return_value = MagicMock()
         make_inference_pipeline(dummy_config, "stochastic")
         _, kwargs = MockRubixPipeline.call_args
         assert kwargs.get("apply_noise_post_aggregation") is True
@@ -37,11 +35,9 @@ def test_make_inference_pipeline_sets_post_aggregation_noise_for_stochastic():
 
 def test_make_inference_pipeline_does_not_set_post_aggregation_noise_for_deterministic():
     dummy_config = {"pipeline": {"name": "calc_gradient"}}
-    mock_pipeline = MagicMock()
-    mock_pipeline._apply_noise_post_aggregation = False
 
     with patch("rubix.inference.modes.RubixPipeline") as MockRubixPipeline:
-        MockRubixPipeline.return_value = mock_pipeline
+        MockRubixPipeline.return_value = MagicMock()
         make_inference_pipeline(dummy_config, "deterministic")
         _, kwargs = MockRubixPipeline.call_args
         assert kwargs.get("apply_noise_post_aggregation") is False

--- a/tests/test_inference_modes.py
+++ b/tests/test_inference_modes.py
@@ -1,0 +1,21 @@
+import pytest
+
+from rubix.inference import get_pipeline_name_for_mode
+
+
+def test_get_pipeline_name_for_mode_gradient_modes():
+    deterministic = get_pipeline_name_for_mode("calc_gradient", "deterministic")
+    stochastic = get_pipeline_name_for_mode("calc_gradient", "stochastic")
+
+    assert deterministic == "calc_gradient_deterministic"
+    assert stochastic == "calc_gradient_stochastic"
+
+
+def test_get_pipeline_name_for_mode_passthrough_for_unknown_pipeline():
+    assert get_pipeline_name_for_mode("calc_ifu", "deterministic") == "calc_ifu"
+    assert get_pipeline_name_for_mode("calc_ifu", "stochastic") == "calc_ifu"
+
+
+def test_get_pipeline_name_for_mode_rejects_invalid_mode():
+    with pytest.raises(ValueError, match="mode must be one of"):
+        get_pipeline_name_for_mode("calc_gradient", "bad")  # type: ignore[arg-type]

--- a/tests/test_telescope_noise.py
+++ b/tests/test_telescope_noise.py
@@ -82,3 +82,24 @@ def test_sample_noise_invalid_type():
 
     with pytest.raises(ValueError, match="Invalid noise type: invalid"):
         sample_noise(shape, type="invalid", key=key)
+
+
+def test_calculate_noise_cube_is_reproducible_with_same_key():
+    cube = jrandom.uniform(jrandom.PRNGKey(0), shape=(4, 4, 8))
+    key = jrandom.PRNGKey(123)
+
+    noise_cube_1 = calculate_noise_cube(cube, 0.8, key=key)
+    noise_cube_2 = calculate_noise_cube(cube, 0.8, key=key)
+
+    assert jnp.allclose(noise_cube_1, noise_cube_2)
+
+
+def test_calculate_noise_cube_changes_with_different_keys():
+    cube = jrandom.uniform(jrandom.PRNGKey(0), shape=(4, 4, 8))
+    key_1 = jrandom.PRNGKey(123)
+    key_2 = jrandom.PRNGKey(456)
+
+    noise_cube_1 = calculate_noise_cube(cube, 0.8, key=key_1)
+    noise_cube_2 = calculate_noise_cube(cube, 0.8, key=key_2)
+
+    assert not jnp.allclose(noise_cube_1, noise_cube_2)


### PR DESCRIPTION
## Summary
- add deterministic and stochastic gradient pipeline configs
- add mode resolver and pipeline factory for inference
- thread optional PRNG keys through inference API and noise path
- add tests for mode mapping, noise-key behavior, and key propagation

## Stack position
PR 3 / 8 in the gradient-production plan