### PR TITLE
test(inference): add finite-difference gradient validation suite

### DIFF
--- a/docs/development/gradient_production_pr_plan.md
+++ b/docs/development/gradient_production_pr_plan.md
@@ -28,10 +28,10 @@ proof-of-concept notebooks to production full-IFU workflows.
 3. `refactor(gradient-modes)` (completed)
 - Separate deterministic and stochastic (PRNG-keyed) gradient paths.
 
-4. `feat(optimizer-loop)` (current)
+4. `feat(optimizer-loop)` (completed)
 - Add reusable Optax optimization loop with histories/checkpoints.
 
-5. `test(gradient-vs-fd)`
+5. `test(gradient-vs-fd)` (current)
 - Add finite-difference validation suite for gradient correctness.
 
 6. `perf(full-ifu-scaling)`

--- a/docs/development/gradient_production_pr_plan.md
+++ b/docs/development/gradient_production_pr_plan.md
@@ -31,10 +31,10 @@ proof-of-concept notebooks to production full-IFU workflows.
 4. `feat(optimizer-loop)` (completed)
 - Add reusable Optax optimization loop with histories/checkpoints.
 
-5. `test(gradient-vs-fd)` (current)
+5. `test(gradient-vs-fd)` (completed)
 - Add finite-difference validation suite for gradient correctness.
 
-6. `perf(full-ifu-scaling)`
+6. `perf(full-ifu-scaling)` (current)
 - Add chunking/checkpointing controls and consistency tests.
 
 7. `feat(variational-inference)`

--- a/rubix/core/ifu.py
+++ b/rubix/core/ifu.py
@@ -34,7 +34,11 @@ def _get_performance_options(config: dict) -> tuple[int, bool]:
     """
     perf_config = config.get("performance", {})
     chunk_size = perf_config.get("particle_chunk_size", 0)
-    if not isinstance(chunk_size, int) or chunk_size <= 0:
+    if (
+        not isinstance(chunk_size, int)
+        or isinstance(chunk_size, bool)
+        or chunk_size <= 0
+    ):
         chunk_size = 0
 
     use_remat = bool(perf_config.get("remat_particlewise", False))

--- a/rubix/core/ifu.py
+++ b/rubix/core/ifu.py
@@ -21,6 +21,84 @@ from .telescope import get_telescope
 
 
 @jaxtyped(typechecker=typechecker)
+def _get_performance_options(config: dict) -> tuple[int, bool]:
+    """Read optional particlewise performance settings from the config.
+
+    Args:
+        config (dict): Runtime configuration dictionary.
+
+    Returns:
+        tuple[int, bool]:
+            ``(chunk_size, use_remat)`` where ``chunk_size == 0`` means
+            unchunked execution.
+    """
+    perf_config = config.get("performance", {})
+    chunk_size = perf_config.get("particle_chunk_size", 0)
+    if not isinstance(chunk_size, int) or chunk_size <= 0:
+        chunk_size = 0
+
+    use_remat = bool(perf_config.get("remat_particlewise", False))
+    return chunk_size, use_remat
+
+
+@jaxtyped(typechecker=typechecker)
+def _scan_particles(
+    init_cube: Float[Array, "n_spaxels n_wave_bins"],
+    nstar: int,
+    step_fn: Callable,
+    chunk_size: int,
+) -> Float[Array, "n_spaxels n_wave_bins"]:
+    """Accumulate per-particle contributions with optional chunking.
+
+    Args:
+        init_cube (Float[Array, "n_spaxels n_wave_bins"]): Initial cube.
+        nstar (int): Number of particles.
+        step_fn (Callable): Particle step function of signature
+            ``(cube, index) -> (cube, aux)``.
+        chunk_size (int): Chunk size; ``0`` disables chunking.
+
+    Returns:
+        Float[Array, "n_spaxels n_wave_bins"]: Accumulated flat cube.
+    """
+    if nstar == 0:
+        return init_cube
+
+    if chunk_size <= 0:
+        cube_flat, _ = lax.scan(step_fn, init_cube, jnp.arange(nstar, dtype=jnp.int32))
+        return cube_flat
+
+    n_chunks = (nstar + chunk_size - 1) // chunk_size
+    max_index = nstar - 1
+
+    def chunk_body(cube, chunk_idx):
+        start = chunk_idx * chunk_size
+        local = jnp.arange(chunk_size, dtype=jnp.int32)
+        idx = start + local
+        idx_safe = jnp.minimum(idx, max_index)
+        valid = idx < nstar
+
+        def inner_body(i, cube_inner):
+            def do_step(current_cube):
+                cube_new, _ = step_fn(current_cube, idx_safe[i])
+                return cube_new
+
+            return lax.cond(
+                valid[i],
+                do_step,
+                lambda current_cube: current_cube,
+                cube_inner,
+            )
+
+        cube = lax.fori_loop(0, chunk_size, inner_body, cube)
+        return cube, None
+
+    cube_flat, _ = lax.scan(
+        chunk_body, init_cube, jnp.arange(n_chunks, dtype=jnp.int32)
+    )
+    return cube_flat
+
+
+@jaxtyped(typechecker=typechecker)
 def get_calculate_datacube_particlewise(config: dict) -> Callable:
     """Prepare a per-particle datacube builder for the star component.
 
@@ -57,6 +135,7 @@ def get_calculate_datacube_particlewise(config: dict) -> Callable:
     ssp_wave0 = cosmological_doppler_shift(
         z=z_obs, wavelength=ssp_model.wavelength
     )  # (n_wave_ssp,)
+    chunk_size, use_remat = _get_performance_options(config)
 
     @jaxtyped(typechecker=typechecker)
     def calculate_datacube_particlewise(rubixdata: RubixData) -> RubixData:
@@ -109,10 +188,15 @@ def get_calculate_datacube_particlewise(config: dict) -> Callable:
             cube = cube.at[pix_i].add(spec_tel)
             return cube, None
 
-        cube_flat, _ = lax.scan(
-            body,
-            init_cube,
-            jnp.arange(nstar, dtype=jnp.int32),
+        particle_step = body
+        if use_remat:
+            particle_step = jax.checkpoint(body)
+
+        cube_flat = _scan_particles(
+            init_cube=init_cube,
+            nstar=nstar,
+            step_fn=particle_step,
+            chunk_size=chunk_size,
         )
 
         cube_3d = cube_flat.reshape(ns, ns, -1)
@@ -160,6 +244,7 @@ def get_calculate_dusty_datacube_particlewise(config: dict) -> Callable:
     ssp_wave0 = cosmological_doppler_shift(
         z=z_obs, wavelength=ssp_model.wavelength
     )  # (n_wave_ssp,)
+    chunk_size, use_remat = _get_performance_options(config)
 
     @jaxtyped(typechecker=typechecker)
     def calculate_dusty_datacube_particlewise(
@@ -237,10 +322,15 @@ def get_calculate_dusty_datacube_particlewise(config: dict) -> Callable:
             cube = cube.at[pix_i].add(spec_extincted)
             return cube, None
 
-        cube_flat, _ = lax.scan(
-            body,
-            init_cube,
-            jnp.arange(nstar, dtype=jnp.int32),
+        particle_step = body
+        if use_remat:
+            particle_step = jax.checkpoint(body)
+
+        cube_flat = _scan_particles(
+            init_cube=init_cube,
+            nstar=nstar,
+            step_fn=particle_step,
+            chunk_size=chunk_size,
         )
 
         cube_3d = cube_flat.reshape(ns, ns, -1)

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -12,16 +12,20 @@ from .parameterization import (
     build_age_metallicity_transforms,
     inverse_transforms,
 )
+from .validation import GradientComparison, compare_gradients, finite_difference_grad
 
 __all__ = [
     "IdentityTransform",
     "ParameterTransform",
     "SigmoidBounds",
     "SoftplusLowerBound",
+    "GradientComparison",
     "OptimizationResult",
     "apply_params",
     "apply_transforms",
     "build_age_metallicity_transforms",
+    "compare_gradients",
+    "finite_difference_grad",
     "forward",
     "get_pipeline_name_for_mode",
     "inverse_transforms",

--- a/rubix/inference/validation.py
+++ b/rubix/inference/validation.py
@@ -49,7 +49,15 @@ def finite_difference_grad(
         basis = jnp.zeros_like(flat).at[i].set(1.0)
         return (f_flat(flat + eps * basis) - f_flat(flat - eps * basis)) / (2.0 * eps)
 
-    grad_flat = jax.vmap(fd_at_index)(jnp.arange(flat.size))
+    def body_fun(i, grad_accum):
+        return grad_accum.at[i].set(fd_at_index(i))
+
+    grad_flat = jax.lax.fori_loop(
+        0,
+        flat.size,
+        body_fun,
+        jnp.zeros_like(flat),
+    )
     return unravel(grad_flat)
 
 

--- a/rubix/inference/validation.py
+++ b/rubix/inference/validation.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+from typing import Callable
+
+import jax
+import jax.numpy as jnp
+from beartype.typing import Any, Mapping
+from jax.flatten_util import ravel_pytree
+
+ParamsTree = Mapping[str, Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class GradientComparison:
+    """Summary metrics comparing autodiff and finite-difference gradients."""
+
+    max_abs_error: float
+    l2_error: float
+    l2_reference: float
+    relative_l2_error: float
+
+
+def finite_difference_grad(
+    loss_fn: Callable[[ParamsTree], jnp.ndarray],
+    params: ParamsTree,
+    eps: float = 1e-5,
+) -> Any:
+    """Compute central finite-difference gradients on an arbitrary pytree.
+
+    Args:
+        loss_fn (Callable[[ParamsTree], jnp.ndarray]): Scalar loss function.
+        params (ParamsTree): Parameter pytree at which to evaluate gradient.
+        eps (float, optional): Central-difference step size. Defaults to 1e-5.
+
+    Raises:
+        ValueError: If ``eps`` is not strictly positive.
+
+    Returns:
+        Any: Pytree gradient matching the structure of ``params``.
+    """
+    if eps <= 0:
+        raise ValueError("eps must be strictly positive")
+
+    flat, unravel = ravel_pytree(params)
+
+    def f_flat(flat_params):
+        return loss_fn(unravel(flat_params))
+
+    def fd_at_index(i):
+        basis = jnp.zeros_like(flat).at[i].set(1.0)
+        return (f_flat(flat + eps * basis) - f_flat(flat - eps * basis)) / (2.0 * eps)
+
+    grad_flat = jax.vmap(fd_at_index)(jnp.arange(flat.size))
+    return unravel(grad_flat)
+
+
+def compare_gradients(autodiff_grad: Any, fd_grad: Any) -> GradientComparison:
+    """Compare autodiff and finite-difference gradients.
+
+    Args:
+        autodiff_grad (Any): Gradient pytree from autodiff.
+        fd_grad (Any): Gradient pytree from finite differences.
+
+    Returns:
+        GradientComparison: Error metrics for the flattened gradient vectors.
+    """
+    auto_flat, _ = ravel_pytree(autodiff_grad)
+    fd_flat, _ = ravel_pytree(fd_grad)
+
+    diff = auto_flat - fd_flat
+    max_abs_error = jnp.max(jnp.abs(diff))
+    l2_error = jnp.linalg.norm(diff)
+    l2_reference = jnp.linalg.norm(fd_flat)
+    relative_l2_error = l2_error / jnp.maximum(l2_reference, 1e-12)
+
+    return GradientComparison(
+        max_abs_error=float(max_abs_error),
+        l2_error=float(l2_error),
+        l2_reference=float(l2_reference),
+        relative_l2_error=float(relative_l2_error),
+    )

--- a/rubix/inference/validation.py
+++ b/rubix/inference/validation.py
@@ -68,12 +68,20 @@ def compare_gradients(autodiff_grad: Any, fd_grad: Any) -> GradientComparison:
         autodiff_grad (Any): Gradient pytree from autodiff.
         fd_grad (Any): Gradient pytree from finite differences.
 
+    Raises:
+        ValueError: If the flattened gradient vectors do not have the same shape.
+
     Returns:
         GradientComparison: Error metrics for the flattened gradient vectors.
     """
     auto_flat, _ = ravel_pytree(autodiff_grad)
     fd_flat, _ = ravel_pytree(fd_grad)
 
+    if auto_flat.shape != fd_flat.shape:
+        raise ValueError(
+            "autodiff_grad and fd_grad must flatten to the same shape; "
+            f"got {auto_flat.shape} and {fd_flat.shape}"
+        )
     diff = auto_flat - fd_flat
     max_abs_error = jnp.max(jnp.abs(diff))
     l2_error = jnp.linalg.norm(diff)

--- a/rubix/inference/validation.py
+++ b/rubix/inference/validation.py
@@ -32,8 +32,8 @@ def finite_difference_grad(
         eps (float, optional): Central-difference step size. Defaults to 1e-5.
 
     Raises:
-        ValueError: If ``eps`` is not strictly positive.
-        ValueError: If ``loss_fn`` does not return a scalar.
+        ValueError: If ``eps`` is not strictly positive, or if ``loss_fn``
+            does not return a scalar.
 
     Returns:
         Any: Pytree gradient matching the structure of ``params``.

--- a/rubix/inference/validation.py
+++ b/rubix/inference/validation.py
@@ -33,12 +33,20 @@ def finite_difference_grad(
 
     Raises:
         ValueError: If ``eps`` is not strictly positive.
+        ValueError: If ``loss_fn`` does not return a scalar.
 
     Returns:
         Any: Pytree gradient matching the structure of ``params``.
     """
     if eps <= 0:
         raise ValueError("eps must be strictly positive")
+
+    sample_output = loss_fn(params)
+    if jnp.ndim(sample_output) != 0:
+        raise ValueError(
+            "loss_fn must return a scalar; "
+            f"got output with shape {jnp.shape(sample_output)}"
+        )
 
     flat, unravel = ravel_pytree(params)
 

--- a/tests/test_core_ifu_scaling.py
+++ b/tests/test_core_ifu_scaling.py
@@ -1,0 +1,66 @@
+import jax.numpy as jnp
+
+from rubix.core.ifu import _get_performance_options, _scan_particles
+
+
+def test_get_performance_options_defaults():
+    chunk_size, use_remat = _get_performance_options({})
+
+    assert chunk_size == 0
+    assert use_remat is False
+
+
+def test_get_performance_options_reads_valid_values():
+    chunk_size, use_remat = _get_performance_options(
+        {"performance": {"particle_chunk_size": 16, "remat_particlewise": True}}
+    )
+
+    assert chunk_size == 16
+    assert use_remat is True
+
+
+def test_get_performance_options_rejects_invalid_chunk_size():
+    chunk_size, use_remat = _get_performance_options(
+        {"performance": {"particle_chunk_size": -5, "remat_particlewise": False}}
+    )
+
+    assert chunk_size == 0
+    assert use_remat is False
+
+
+def _simple_step(cube, i):
+    update = jnp.full_like(cube, i + 1, dtype=cube.dtype)
+    return cube + update, None
+
+
+def test_scan_particles_chunked_matches_unchunked():
+    init_cube = jnp.zeros((3, 4), dtype=jnp.float32)
+    nstar = 11
+
+    unchunked = _scan_particles(
+        init_cube=init_cube,
+        nstar=nstar,
+        step_fn=_simple_step,
+        chunk_size=0,
+    )
+    chunked = _scan_particles(
+        init_cube=init_cube,
+        nstar=nstar,
+        step_fn=_simple_step,
+        chunk_size=4,
+    )
+
+    assert jnp.allclose(unchunked, chunked)
+
+
+def test_scan_particles_returns_init_for_empty_input():
+    init_cube = jnp.ones((2, 2), dtype=jnp.float32)
+
+    result = _scan_particles(
+        init_cube=init_cube,
+        nstar=0,
+        step_fn=_simple_step,
+        chunk_size=8,
+    )
+
+    assert jnp.allclose(result, init_cube)

--- a/tests/test_inference_gradient_validation.py
+++ b/tests/test_inference_gradient_validation.py
@@ -142,3 +142,21 @@ def test_finite_difference_grad_rejects_non_positive_eps():
 
     with pytest.raises(ValueError, match="eps must be strictly positive"):
         finite_difference_grad(lambda p: jnp.sum(p["stars"]["age"]), params, eps=0.0)
+
+
+def test_finite_difference_grad_rejects_non_scalar_loss_fn():
+    params = _params_init()
+
+    def non_scalar_loss(p):
+        return p["stars"]["age"]  # returns a 1-D array, not a scalar
+
+    with pytest.raises(ValueError, match="loss_fn must return a scalar"):
+        finite_difference_grad(non_scalar_loss, params)
+
+
+def test_compare_gradients_rejects_mismatched_shapes():
+    grad_a = {"stars": {"age": jnp.array([1.0, 2.0])}}
+    grad_b = {"stars": {"age": jnp.array([1.0, 2.0, 3.0])}}
+
+    with pytest.raises(ValueError, match="same shape"):
+        compare_gradients(grad_a, grad_b)

--- a/tests/test_inference_gradient_validation.py
+++ b/tests/test_inference_gradient_validation.py
@@ -1,0 +1,144 @@
+import jax.numpy as jnp
+import jax.random as jrandom
+import pytest
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import (
+    compare_gradients,
+    finite_difference_grad,
+    loss,
+    value_and_grad,
+)
+
+
+class DeterministicDummyPipeline:
+    """Simple deterministic forward model."""
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        age_sum = jnp.sum(rubixdata.stars.age)
+        metallicity_sum = jnp.sum(rubixdata.stars.metallicity)
+        prediction = age_sum + 2.0 * metallicity_sum
+        return jnp.reshape(prediction, (1, 1, 1))
+
+
+class StochasticDummyPipeline:
+    """Forward model where outputs depend on a fixed PRNG key."""
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        age_sum = jnp.sum(rubixdata.stars.age)
+        metallicity_sum = jnp.sum(rubixdata.stars.metallicity)
+        base = age_sum + 2.0 * metallicity_sum
+
+        key = rubixdata.noise_key
+        if key is None:
+            key = jrandom.PRNGKey(0)
+
+        noise = 0.1 * jrandom.normal(key, ())
+        prediction = base * (1.0 + noise)
+        return jnp.reshape(prediction, (1, 1, 1))
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((2, 3)),
+            velocity=jnp.zeros((2, 3)),
+            mass=jnp.ones(2),
+            age=jnp.array([1.0, 1.0]),
+            metallicity=jnp.array([0.01, 0.02]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def _params_init():
+    return {
+        "stars": {
+            "age": jnp.array([1.5, 2.0]),
+            "metallicity": jnp.array([0.015, 0.025]),
+        }
+    }
+
+
+def test_finite_difference_grad_matches_autodiff_deterministic():
+    pipeline = DeterministicDummyPipeline()
+    static_data = _make_rubix_data()
+    params = _params_init()
+    target = jnp.array([[[4.5]]])
+
+    def loss_fn(current_params):
+        return loss(
+            pipeline=pipeline,
+            params=current_params,
+            static_data=static_data,
+            target=target,
+        )
+
+    autodiff_grad = value_and_grad(
+        pipeline=pipeline,
+        params=params,
+        static_data=static_data,
+        target=target,
+    )[1]
+    fd_grad = finite_difference_grad(loss_fn, params, eps=1e-4)
+    comparison = compare_gradients(autodiff_grad, fd_grad)
+
+    assert comparison.max_abs_error < 1e-2
+    assert comparison.relative_l2_error < 1e-3
+
+
+def test_finite_difference_grad_matches_autodiff_fixed_stochastic_key():
+    pipeline = StochasticDummyPipeline()
+    static_data = _make_rubix_data()
+    params = _params_init()
+    target = jnp.array([[[4.5]]])
+    noise_key = jrandom.PRNGKey(17)
+
+    def loss_fn(current_params):
+        return loss(
+            pipeline=pipeline,
+            params=current_params,
+            static_data=static_data,
+            target=target,
+            noise_key=noise_key,
+        )
+
+    autodiff_grad = value_and_grad(
+        pipeline=pipeline,
+        params=params,
+        static_data=static_data,
+        target=target,
+        noise_key=noise_key,
+    )[1]
+    fd_grad = finite_difference_grad(loss_fn, params, eps=1e-4)
+    comparison = compare_gradients(autodiff_grad, fd_grad)
+
+    assert comparison.max_abs_error < 1e-2
+    assert comparison.relative_l2_error < 1e-3
+
+
+def test_compare_gradients_is_zero_for_identical_gradients():
+    gradient = {
+        "stars": {
+            "age": jnp.array([1.0, 2.0]),
+            "metallicity": jnp.array([3.0]),
+        }
+    }
+
+    comparison = compare_gradients(gradient, gradient)
+
+    assert comparison.max_abs_error == 0.0
+    assert comparison.l2_error == 0.0
+    assert comparison.relative_l2_error == 0.0
+
+
+def test_finite_difference_grad_rejects_non_positive_eps():
+    params = _params_init()
+
+    with pytest.raises(ValueError, match="eps must be strictly positive"):
+        finite_difference_grad(lambda p: jnp.sum(p["stars"]["age"]), params, eps=0.0)


### PR DESCRIPTION
## Summary
- add reusable finite-difference gradient utility for pytrees
- add gradient comparison metrics helper
- add tests comparing autodiff and finite-difference gradients
- cover deterministic and fixed-key stochastic settings

## Stack position
PR 5 / 8 in the gradient-production plan