### PR TITLE
feat(inference): add mean-field variational inference scaffold

### DIFF
--- a/docs/development/gradient_production_pr_plan.md
+++ b/docs/development/gradient_production_pr_plan.md
@@ -37,8 +37,8 @@ proof-of-concept notebooks to production full-IFU workflows.
 6. `perf(full-ifu-scaling)` (completed)
 - Add chunking/checkpointing controls and consistency tests.
 
-7. `feat(variational-inference)` (current)
+7. `feat(variational-inference)` (completed)
 - Add first VI scaffold (mean-field baseline) on top of inference API.
 
-8. `docs(examples-and-guides)`
+8. `docs(examples-and-guides)` (completed)
 - Add production examples and API docs for inverse modeling workflows.

--- a/docs/development/gradient_production_pr_plan.md
+++ b/docs/development/gradient_production_pr_plan.md
@@ -34,10 +34,10 @@ proof-of-concept notebooks to production full-IFU workflows.
 5. `test(gradient-vs-fd)` (completed)
 - Add finite-difference validation suite for gradient correctness.
 
-6. `perf(full-ifu-scaling)` (current)
+6. `perf(full-ifu-scaling)` (completed)
 - Add chunking/checkpointing controls and consistency tests.
 
-7. `feat(variational-inference)`
+7. `feat(variational-inference)` (current)
 - Add first VI scaffold (mean-field baseline) on top of inference API.
 
 8. `docs(examples-and-guides)`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ If you use the code in your research, please cite the following paper: :ref:`pub
    installation
    versions
    publications
+   inference_workflows
    license
    acknowledgments
 
@@ -80,6 +81,7 @@ Code base documentation
    rubix.core
    rubix.cosmology
    rubix.galaxy
+   rubix.inference
    rubix.pipeline
    rubix.spectra
    rubix.telescope

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -72,7 +72,7 @@ finite-difference estimates.
 
 .. code-block:: python
 
-   from rubix.inference import compare_gradients, finite_difference_grad, value_and_grad
+   from rubix.inference import compare_gradients, finite_difference_grad, loss, value_and_grad
 
    def objective(p):
        return loss(

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -1,0 +1,130 @@
+Inference Workflows
+===================
+
+This page summarizes the production-ready inference interfaces added to Rubix
+for gradient-based optimization and variational inference on IFU models.
+
+Overview
+--------
+
+The inference stack lives in ``rubix.inference`` and provides:
+
+- parameter application and forward/loss wrappers
+- deterministic vs stochastic gradient pipeline mode selection
+- constrained parameter transforms (age/metallicity defaults)
+- Optax-based optimization loops
+- finite-difference gradient validation helpers
+- a first mean-field variational inference scaffold
+
+Deterministic vs Stochastic Modes
+---------------------------------
+
+Use deterministic mode for stable gradient-based fitting and finite-difference
+validation, and stochastic mode for likelihood/noise-aware workflows.
+
+.. code-block:: python
+
+   from rubix.inference import make_inference_pipeline
+
+   pipe_det = make_inference_pipeline(config, mode="deterministic")
+   pipe_sto = make_inference_pipeline(config, mode="stochastic")
+
+
+Gradient-Based Optimization
+---------------------------
+
+The standard optimization entrypoint is ``optimize_params``.
+
+.. code-block:: python
+
+   import jax.numpy as jnp
+   from rubix.inference import (
+       build_age_metallicity_transforms,
+       optimize_params,
+   )
+
+   transforms = build_age_metallicity_transforms(
+       age_lower=0.0,
+       age_upper=20.0,
+       metallicity_lower=0.0,
+       metallicity_upper=0.05,
+   )
+
+   result = optimize_params(
+       pipeline=pipe_det,
+       params_init=params_init,
+       static_data=static_data,
+       target=target_cube,
+       transforms=transforms,
+       learning_rate=1e-2,
+       max_steps=500,
+       tol=1e-6,
+   )
+
+   optimized = result.params
+
+
+Finite-Difference Gradient Validation
+-------------------------------------
+
+Use the validation helpers to compare autodiff gradients and central
+finite-difference estimates.
+
+.. code-block:: python
+
+   from rubix.inference import compare_gradients, finite_difference_grad, value_and_grad
+
+   def objective(p):
+       return loss(
+           pipeline=pipe_det,
+           params=p,
+           static_data=static_data,
+           target=target_cube,
+       )
+
+   _, auto_grad = value_and_grad(
+       pipeline=pipe_det,
+       params=params_init,
+       static_data=static_data,
+       target=target_cube,
+   )
+   fd_grad = finite_difference_grad(objective, params_init, eps=1e-4)
+   summary = compare_gradients(auto_grad, fd_grad)
+
+   print(summary.max_abs_error, summary.relative_l2_error)
+
+
+Mean-Field Variational Inference
+--------------------------------
+
+Use ``optimize_variational_posterior`` for a first diagonal-Gaussian posterior.
+
+.. code-block:: python
+
+   from rubix.inference import optimize_variational_posterior
+
+   vi = optimize_variational_posterior(
+       pipeline=pipe_det,
+       params_init=params_init,
+       static_data=static_data,
+       target=target_cube,
+       learning_rate=5e-3,
+       num_samples=4,
+       beta_kl=1e-3,
+       max_steps=500,
+   )
+
+   posterior_mean = vi.posterior_mean_params
+   posterior_log_std = vi.posterior_log_std_params
+
+
+Performance Notes
+-----------------
+
+For large particle counts, configure optional IFU accumulation controls:
+
+- ``performance.particle_chunk_size``: chunked particle accumulation
+- ``performance.remat_particlewise``: rematerialization/checkpointing of the
+  particle step function for memory/computation tradeoffs
+
+These settings are used by the particlewise IFU builders in ``rubix.core.ifu``.

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -1,0 +1,61 @@
+rubix.inference package
+=======================
+
+Submodules
+----------
+
+rubix.inference.api module
+--------------------------
+
+.. automodule:: rubix.inference.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.modes module
+----------------------------
+
+.. automodule:: rubix.inference.modes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.optimize module
+-------------------------------
+
+.. automodule:: rubix.inference.optimize
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.parameterization module
+---------------------------------------
+
+.. automodule:: rubix.inference.parameterization
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.validation module
+---------------------------------
+
+.. automodule:: rubix.inference.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.variational module
+----------------------------------
+
+.. automodule:: rubix.inference.variational
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: rubix.inference
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/rubix.rst
+++ b/docs/rubix.rst
@@ -10,6 +10,7 @@ Subpackages
    rubix.core
    rubix.cosmology
    rubix.galaxy
+   rubix.inference
    rubix.pipeline
    rubix.spectra
    rubix.telescope

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -13,6 +13,13 @@ from .parameterization import (
     inverse_transforms,
 )
 from .validation import GradientComparison, compare_gradients, finite_difference_grad
+from .variational import (
+    VariationalResult,
+    initialize_mean_field_params,
+    kl_diag_gaussian_to_standard_normal,
+    optimize_variational_posterior,
+    sample_diag_gaussian,
+)
 
 __all__ = [
     "IdentityTransform",
@@ -21,6 +28,7 @@ __all__ = [
     "SoftplusLowerBound",
     "GradientComparison",
     "OptimizationResult",
+    "VariationalResult",
     "apply_params",
     "apply_transforms",
     "build_age_metallicity_transforms",
@@ -31,6 +39,10 @@ __all__ = [
     "inverse_transforms",
     "loss",
     "make_inference_pipeline",
+    "initialize_mean_field_params",
+    "kl_diag_gaussian_to_standard_normal",
+    "optimize_variational_posterior",
     "optimize_params",
+    "sample_diag_gaussian",
     "value_and_grad",
 ]

--- a/rubix/inference/variational.py
+++ b/rubix/inference/variational.py
@@ -1,0 +1,261 @@
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+import jax
+import jax.numpy as jnp
+import optax
+from beartype.typing import Any
+
+from .api import LossFn, loss
+from .parameterization import TransformTree, apply_transforms
+
+ParamsTree = Mapping[str, Mapping[str, Any]]
+
+
+@dataclass
+class VariationalResult:
+    """Container for mean-field variational optimization outputs."""
+
+    posterior_mean_params: dict[str, dict[str, Any]]
+    posterior_log_std_params: dict[str, dict[str, Any]]
+    best_posterior_mean_params: dict[str, dict[str, Any]]
+    objective_history: list[float]
+    reconstruction_history: list[float]
+    kl_history: list[float]
+    best_objective: float
+    steps_run: int
+    converged: bool
+
+
+def _tree_to_dict(tree: ParamsTree) -> dict[str, dict[str, Any]]:
+    """Return a mutable dictionary copy from a nested parameter tree."""
+    return {component: dict(fields) for component, fields in tree.items()}
+
+
+def initialize_mean_field_params(
+    params_init: ParamsTree,
+    init_log_std: float = -2.0,
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Initialize diagonal Gaussian variational parameters.
+
+    Args:
+        params_init (ParamsTree): Initial point for posterior means.
+        init_log_std (float, optional): Initial log standard deviation for all
+            leaves. Defaults to -2.0.
+
+    Returns:
+        tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+            Posterior mean and posterior log-std pytrees.
+    """
+    mean = _tree_to_dict(params_init)
+    log_std = jax.tree_util.tree_map(
+        lambda x: jnp.zeros_like(x) + init_log_std,  # noqa: B023
+        mean,
+    )
+    return mean, _tree_to_dict(log_std)
+
+
+def sample_diag_gaussian(
+    mean: ParamsTree,
+    log_std: ParamsTree,
+    key: jnp.ndarray,
+) -> dict[str, dict[str, Any]]:
+    """Sample a pytree from a diagonal Gaussian posterior."""
+    # Reconstruct a key tree matching ``mean`` leaves.
+    treedef = jax.tree_util.tree_structure(mean)
+    key_tree = jax.tree_util.tree_unflatten(
+        treedef,
+        list(jax.random.split(key, treedef.num_leaves)),
+    )
+    eps = jax.tree_util.tree_map(
+        lambda x, k: jax.random.normal(k, shape=x.shape, dtype=x.dtype),
+        mean,
+        key_tree,
+    )
+    sample = jax.tree_util.tree_map(
+        lambda m, ls, e: m + jnp.exp(ls) * e,  # noqa: B023
+        mean,
+        log_std,
+        eps,
+    )
+    return _tree_to_dict(sample)
+
+
+def kl_diag_gaussian_to_standard_normal(
+    mean: ParamsTree,
+    log_std: ParamsTree,
+) -> jnp.ndarray:
+    """Compute KL[q||p] for diagonal q vs standard normal prior p."""
+    mean_flat, _ = jax.flatten_util.ravel_pytree(mean)
+    log_std_flat, _ = jax.flatten_util.ravel_pytree(log_std)
+    var_flat = jnp.exp(2.0 * log_std_flat)
+    kl = 0.5 * jnp.sum(var_flat + mean_flat**2 - 1.0 - 2.0 * log_std_flat)
+    return kl
+
+
+def optimize_variational_posterior(
+    pipeline: Any,
+    params_init: ParamsTree,
+    static_data: Any,
+    target: jnp.ndarray,
+    learning_rate: float = 5e-3,
+    max_steps: int = 500,
+    tol: float = 1e-6,
+    num_samples: int = 4,
+    beta_kl: float = 1e-3,
+    init_log_std: float = -2.0,
+    loss_fn: Optional[LossFn] = None,
+    noise_key: Optional[jnp.ndarray] = None,
+    transforms: Optional[TransformTree] = None,
+    optimizer: Optional[optax.GradientTransformation] = None,
+    seed: int = 0,
+) -> VariationalResult:
+    """Optimize a mean-field variational posterior with reparameterization.
+
+    Args:
+        pipeline (Any): Pipeline-like object consumed by :func:`rubix.inference.loss`.
+        params_init (ParamsTree): Initial constrained parameter point.
+        static_data (Any): Baseline RubixData passed to the forward model.
+        target (jnp.ndarray): Target datacube or statistic.
+        learning_rate (float, optional): Step size for default Adam optimizer.
+            Defaults to 5e-3.
+        max_steps (int, optional): Maximum optimization steps. Defaults to 500.
+        tol (float, optional): Convergence threshold on update norm.
+            Defaults to 1e-6.
+        num_samples (int, optional): Monte Carlo samples per step. Defaults to 4.
+        beta_kl (float, optional): KL weight. Defaults to 1e-3.
+        init_log_std (float, optional): Initial posterior log-std. Defaults to -2.0.
+        loss_fn (Optional[LossFn], optional): Optional custom reconstruction loss.
+            Defaults to ``None`` (sum-of-squares).
+        noise_key (Optional[jnp.ndarray], optional): Optional key for stochastic
+            pipelines. Defaults to ``None``.
+        transforms (Optional[TransformTree], optional): Optional transform tree
+            to map unconstrained latent variables to constrained parameters.
+            Defaults to ``None``.
+        optimizer (Optional[optax.GradientTransformation], optional): Custom
+            optimizer. Defaults to ``None`` (Adam).
+        seed (int, optional): Random seed for VI sampling. Defaults to 0.
+
+    Raises:
+        ValueError: If ``num_samples`` is not strictly positive.
+
+    Returns:
+        VariationalResult: Posterior statistics and optimization traces.
+    """
+    if num_samples <= 0:
+        raise ValueError("num_samples must be strictly positive")
+
+    if optimizer is None:
+        optimizer = optax.adam(learning_rate)
+
+    if transforms is None:
+        unconstrained_init = _tree_to_dict(params_init)
+    else:
+        unconstrained_init = apply_transforms(
+            params=params_init,
+            transforms=transforms,
+            direction="inverse",
+        )
+
+    mean, log_std = initialize_mean_field_params(
+        params_init=unconstrained_init,
+        init_log_std=init_log_std,
+    )
+    variational_params = {"mean": mean, "log_std": log_std}
+    opt_state = optimizer.init(variational_params)
+
+    objective_history: list[float] = []
+    reconstruction_history: list[float] = []
+    kl_history: list[float] = []
+
+    best_objective = jnp.inf
+    best_mean = mean
+    converged = False
+    steps_run = 0
+    key = jax.random.PRNGKey(seed)
+
+    def objective_fn(current_params, step_key):
+        current_mean = current_params["mean"]
+        current_log_std = current_params["log_std"]
+        sample_keys = jax.random.split(step_key, num_samples)
+
+        def sample_reconstruction(sample_key):
+            sampled_unconstrained = sample_diag_gaussian(
+                current_mean, current_log_std, sample_key
+            )
+            if transforms is None:
+                sampled_constrained = sampled_unconstrained
+            else:
+                sampled_constrained = apply_transforms(
+                    params=sampled_unconstrained,
+                    transforms=transforms,
+                    direction="forward",
+                )
+            return loss(
+                pipeline=pipeline,
+                params=sampled_constrained,
+                static_data=static_data,
+                target=target,
+                loss_fn=loss_fn,
+                noise_key=noise_key,
+            )
+
+        reconstructions = jax.vmap(sample_reconstruction)(sample_keys)
+        reconstruction = jnp.mean(reconstructions)
+        kl = kl_diag_gaussian_to_standard_normal(current_mean, current_log_std)
+        objective = reconstruction + beta_kl * kl
+        return objective, (reconstruction, kl)
+
+    def objective_only(current_params, step_key):
+        value, _ = objective_fn(current_params, step_key)
+        return value
+
+    for step in range(max_steps):
+        key, step_key = jax.random.split(key)
+        value, grads = jax.value_and_grad(objective_only)(variational_params, step_key)
+        updates, opt_state = optimizer.update(grads, opt_state, variational_params)
+        variational_params = optax.apply_updates(variational_params, updates)
+
+        _, (reconstruction_value, kl_value) = objective_fn(variational_params, step_key)
+        objective_history.append(float(value))
+        reconstruction_history.append(float(reconstruction_value))
+        kl_history.append(float(kl_value))
+
+        if value < best_objective:
+            best_objective = value
+            best_mean = variational_params["mean"]
+
+        steps_run = step + 1
+        if float(optax.global_norm(updates)) < tol:
+            converged = True
+            break
+
+    final_mean = variational_params["mean"]
+    final_log_std = variational_params["log_std"]
+
+    if transforms is None:
+        posterior_mean_constrained = final_mean
+        best_posterior_mean_constrained = best_mean
+    else:
+        posterior_mean_constrained = apply_transforms(
+            params=final_mean,
+            transforms=transforms,
+            direction="forward",
+        )
+        best_posterior_mean_constrained = apply_transforms(
+            params=best_mean,
+            transforms=transforms,
+            direction="forward",
+        )
+
+    return VariationalResult(
+        posterior_mean_params=_tree_to_dict(posterior_mean_constrained),
+        posterior_log_std_params=_tree_to_dict(final_log_std),
+        best_posterior_mean_params=_tree_to_dict(best_posterior_mean_constrained),
+        objective_history=objective_history,
+        reconstruction_history=reconstruction_history,
+        kl_history=kl_history,
+        best_objective=float(best_objective),
+        steps_run=steps_run,
+        converged=converged,
+    )

--- a/rubix/inference/variational.py
+++ b/rubix/inference/variational.py
@@ -14,11 +14,21 @@ ParamsTree = Mapping[str, Mapping[str, Any]]
 
 @dataclass
 class VariationalResult:
-    """Container for mean-field variational optimization outputs."""
+    """Container for mean-field variational optimization outputs.
+
+    All ``*_params`` fields are in the **latent (unconstrained)** space so that
+    ``posterior_mean_params`` and ``posterior_log_std_params`` consistently
+    describe the same diagonal Gaussian that was optimized.  When transforms
+    were supplied the corresponding ``*_constrained_params`` fields hold the
+    mapped constrained values; without transforms they are identical to the
+    latent fields.
+    """
 
     posterior_mean_params: dict[str, dict[str, Any]]
     posterior_log_std_params: dict[str, dict[str, Any]]
+    posterior_mean_constrained_params: dict[str, dict[str, Any]]
     best_posterior_mean_params: dict[str, dict[str, Any]]
+    best_posterior_mean_constrained_params: dict[str, dict[str, Any]]
     objective_history: list[float]
     reconstruction_history: list[float]
     kl_history: list[float]
@@ -206,24 +216,28 @@ def optimize_variational_posterior(
         objective = reconstruction + beta_kl * kl
         return objective, (reconstruction, kl)
 
-    def objective_only(current_params, step_key):
-        value, _ = objective_fn(current_params, step_key)
-        return value
-
     for step in range(max_steps):
         key, step_key = jax.random.split(key)
-        value, grads = jax.value_and_grad(objective_only)(variational_params, step_key)
-        updates, opt_state = optimizer.update(grads, opt_state, variational_params)
-        variational_params = optax.apply_updates(variational_params, updates)
 
-        _, (reconstruction_value, kl_value) = objective_fn(variational_params, step_key)
-        objective_history.append(float(value))
-        reconstruction_history.append(float(reconstruction_value))
-        kl_history.append(float(kl_value))
+        # Compute objective, auxiliary metrics, and gradients all at the
+        # *same* pre-update parameter state so that the three history arrays
+        # remain consistent with each other.
+        (value, (reconstruction_value, kl_value)), grads = jax.value_and_grad(
+            objective_fn, has_aux=True
+        )(variational_params, step_key)
 
+        # Record the best parameter state *before* applying the update so that
+        # best_mean and best_objective correspond to the same parameter state.
         if value < best_objective:
             best_objective = value
             best_mean = variational_params["mean"]
+
+        updates, opt_state = optimizer.update(grads, opt_state, variational_params)
+        variational_params = optax.apply_updates(variational_params, updates)
+
+        objective_history.append(float(value))
+        reconstruction_history.append(float(reconstruction_value))
+        kl_history.append(float(kl_value))
 
         steps_run = step + 1
         if float(optax.global_norm(updates)) < tol:
@@ -249,9 +263,13 @@ def optimize_variational_posterior(
         )
 
     return VariationalResult(
-        posterior_mean_params=_tree_to_dict(posterior_mean_constrained),
+        posterior_mean_params=_tree_to_dict(final_mean),
         posterior_log_std_params=_tree_to_dict(final_log_std),
-        best_posterior_mean_params=_tree_to_dict(best_posterior_mean_constrained),
+        posterior_mean_constrained_params=_tree_to_dict(posterior_mean_constrained),
+        best_posterior_mean_params=_tree_to_dict(best_mean),
+        best_posterior_mean_constrained_params=_tree_to_dict(
+            best_posterior_mean_constrained
+        ),
         objective_history=objective_history,
         reconstruction_history=reconstruction_history,
         kl_history=kl_history,

--- a/tests/test_inference_variational.py
+++ b/tests/test_inference_variational.py
@@ -1,0 +1,161 @@
+import jax.numpy as jnp
+import pytest
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import (
+    build_age_metallicity_transforms,
+    initialize_mean_field_params,
+    kl_diag_gaussian_to_standard_normal,
+    optimize_variational_posterior,
+    sample_diag_gaussian,
+)
+
+
+class DummyPipeline:
+    """Simple differentiable pipeline used for VI tests."""
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        age_sum = jnp.sum(rubixdata.stars.age)
+        metallicity_sum = jnp.sum(rubixdata.stars.metallicity)
+        value = age_sum + 2.0 * metallicity_sum
+        return jnp.reshape(value, (1, 1, 1))
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([1.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_kl_diag_gaussian_is_zero_for_standard_normal():
+    mean = {"stars": {"age": jnp.array([0.0]), "metallicity": jnp.array([0.0])}}
+    log_std = {"stars": {"age": jnp.array([0.0]), "metallicity": jnp.array([0.0])}}
+
+    kl = kl_diag_gaussian_to_standard_normal(mean, log_std)
+
+    assert jnp.allclose(kl, 0.0)
+
+
+def test_initialize_and_sample_mean_field_params():
+    params_init = {
+        "stars": {
+            "age": jnp.array([1.5]),
+            "metallicity": jnp.array([0.02]),
+        }
+    }
+    mean, log_std = initialize_mean_field_params(params_init, init_log_std=-1.5)
+    sample = sample_diag_gaussian(
+        mean,
+        log_std,
+        key=jnp.array([0, 7], dtype=jnp.uint32),
+    )
+
+    assert jnp.allclose(mean["stars"]["age"], params_init["stars"]["age"])
+    assert jnp.allclose(
+        mean["stars"]["metallicity"],
+        params_init["stars"]["metallicity"],
+    )
+    assert jnp.allclose(log_std["stars"]["age"], jnp.array([-1.5]))
+    assert jnp.allclose(log_std["stars"]["metallicity"], jnp.array([-1.5]))
+    assert sample["stars"]["age"].shape == params_init["stars"]["age"].shape
+    assert (
+        sample["stars"]["metallicity"].shape
+        == params_init["stars"]["metallicity"].shape
+    )
+
+
+def test_optimize_variational_posterior_improves_objective():
+    pipeline = DummyPipeline()
+    static_data = _make_rubix_data()
+    params_init = {
+        "stars": {
+            "age": jnp.array([0.5]),
+            "metallicity": jnp.array([0.001]),
+        }
+    }
+    target = jnp.array([[[5.0]]])
+
+    result = optimize_variational_posterior(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=5e-2,
+        max_steps=200,
+        tol=1e-9,
+        num_samples=4,
+        beta_kl=1e-4,
+        seed=11,
+    )
+
+    assert result.objective_history[0] > result.objective_history[-1]
+    assert len(result.reconstruction_history) == len(result.objective_history)
+    assert len(result.kl_history) == len(result.objective_history)
+    assert result.steps_run <= 200
+
+
+def test_optimize_variational_with_transforms_respects_bounds():
+    pipeline = DummyPipeline()
+    static_data = _make_rubix_data()
+    params_init = {
+        "stars": {
+            "age": jnp.array([0.5]),
+            "metallicity": jnp.array([0.001]),
+        }
+    }
+    transforms = build_age_metallicity_transforms(
+        age_lower=0.0,
+        age_upper=20.0,
+        metallicity_lower=0.0,
+        metallicity_upper=0.05,
+    )
+
+    result = optimize_variational_posterior(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=jnp.array([[[7.04]]]),
+        learning_rate=5e-2,
+        max_steps=200,
+        tol=1e-9,
+        num_samples=4,
+        beta_kl=1e-4,
+        transforms=transforms,
+        seed=13,
+    )
+
+    mean_age = result.posterior_mean_params["stars"]["age"]
+    mean_metallicity = result.posterior_mean_params["stars"]["metallicity"]
+
+    assert jnp.all(mean_age > 0.0)
+    assert jnp.all(mean_age < 20.0)
+    assert jnp.all(mean_metallicity > 0.0)
+    assert jnp.all(mean_metallicity < 0.05)
+
+
+def test_optimize_variational_rejects_non_positive_num_samples():
+    with pytest.raises(ValueError, match="num_samples must be strictly positive"):
+        optimize_variational_posterior(
+            pipeline=DummyPipeline(),
+            params_init={
+                "stars": {
+                    "age": jnp.array([0.5]),
+                    "metallicity": jnp.array([0.001]),
+                }
+            },
+            static_data=_make_rubix_data(),
+            target=jnp.array([[[5.0]]]),
+            num_samples=0,
+        )

--- a/tests/test_inference_variational.py
+++ b/tests/test_inference_variational.py
@@ -136,8 +136,8 @@ def test_optimize_variational_with_transforms_respects_bounds():
         seed=13,
     )
 
-    mean_age = result.posterior_mean_params["stars"]["age"]
-    mean_metallicity = result.posterior_mean_params["stars"]["metallicity"]
+    mean_age = result.posterior_mean_constrained_params["stars"]["age"]
+    mean_metallicity = result.posterior_mean_constrained_params["stars"]["metallicity"]
 
     assert jnp.all(mean_age > 0.0)
     assert jnp.all(mean_age < 20.0)


### PR DESCRIPTION
## Summary
- add first mean-field variational inference scaffold for Rubix inference
- implement diagonal Gaussian posterior initialization, sampling, and KL helper
- add variational optimization loop with reparameterized Monte Carlo objective
- add unit tests for KL properties, sampling, and VI optimization behavior

## Stack position
PR 7 / 8 in the gradient-production plan