### PR TITLE
docs(inference): add production workflow and API guides

### DIFF
--- a/docs/development/gradient_production_pr_plan.md
+++ b/docs/development/gradient_production_pr_plan.md
@@ -37,8 +37,8 @@ proof-of-concept notebooks to production full-IFU workflows.
 6. `perf(full-ifu-scaling)` (completed)
 - Add chunking/checkpointing controls and consistency tests.
 
-7. `feat(variational-inference)` (current)
+7. `feat(variational-inference)` (completed)
 - Add first VI scaffold (mean-field baseline) on top of inference API.
 
-8. `docs(examples-and-guides)`
+8. `docs(examples-and-guides)` (completed)
 - Add production examples and API docs for inverse modeling workflows.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ If you use the code in your research, please cite the following paper: :ref:`pub
    installation
    versions
    publications
+   inference_workflows
    license
    acknowledgments
 
@@ -80,6 +81,7 @@ Code base documentation
    rubix.core
    rubix.cosmology
    rubix.galaxy
+   rubix.inference
    rubix.pipeline
    rubix.spectra
    rubix.telescope

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -72,7 +72,7 @@ finite-difference estimates.
 
 .. code-block:: python
 
-   from rubix.inference import compare_gradients, finite_difference_grad, value_and_grad
+   from rubix.inference import compare_gradients, finite_difference_grad, loss, value_and_grad
 
    def objective(p):
        return loss(

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -1,0 +1,130 @@
+Inference Workflows
+===================
+
+This page summarizes the production-ready inference interfaces added to Rubix
+for gradient-based optimization and variational inference on IFU models.
+
+Overview
+--------
+
+The inference stack lives in ``rubix.inference`` and provides:
+
+- parameter application and forward/loss wrappers
+- deterministic vs stochastic gradient pipeline mode selection
+- constrained parameter transforms (age/metallicity defaults)
+- Optax-based optimization loops
+- finite-difference gradient validation helpers
+- a first mean-field variational inference scaffold
+
+Deterministic vs Stochastic Modes
+---------------------------------
+
+Use deterministic mode for stable gradient-based fitting and finite-difference
+validation, and stochastic mode for likelihood/noise-aware workflows.
+
+.. code-block:: python
+
+   from rubix.inference import make_inference_pipeline
+
+   pipe_det = make_inference_pipeline(config, mode="deterministic")
+   pipe_sto = make_inference_pipeline(config, mode="stochastic")
+
+
+Gradient-Based Optimization
+---------------------------
+
+The standard optimization entrypoint is ``optimize_params``.
+
+.. code-block:: python
+
+   import jax.numpy as jnp
+   from rubix.inference import (
+       build_age_metallicity_transforms,
+       optimize_params,
+   )
+
+   transforms = build_age_metallicity_transforms(
+       age_lower=0.0,
+       age_upper=20.0,
+       metallicity_lower=0.0,
+       metallicity_upper=0.05,
+   )
+
+   result = optimize_params(
+       pipeline=pipe_det,
+       params_init=params_init,
+       static_data=static_data,
+       target=target_cube,
+       transforms=transforms,
+       learning_rate=1e-2,
+       max_steps=500,
+       tol=1e-6,
+   )
+
+   optimized = result.params
+
+
+Finite-Difference Gradient Validation
+-------------------------------------
+
+Use the validation helpers to compare autodiff gradients and central
+finite-difference estimates.
+
+.. code-block:: python
+
+   from rubix.inference import compare_gradients, finite_difference_grad, value_and_grad
+
+   def objective(p):
+       return loss(
+           pipeline=pipe_det,
+           params=p,
+           static_data=static_data,
+           target=target_cube,
+       )
+
+   _, auto_grad = value_and_grad(
+       pipeline=pipe_det,
+       params=params_init,
+       static_data=static_data,
+       target=target_cube,
+   )
+   fd_grad = finite_difference_grad(objective, params_init, eps=1e-4)
+   summary = compare_gradients(auto_grad, fd_grad)
+
+   print(summary.max_abs_error, summary.relative_l2_error)
+
+
+Mean-Field Variational Inference
+--------------------------------
+
+Use ``optimize_variational_posterior`` for a first diagonal-Gaussian posterior.
+
+.. code-block:: python
+
+   from rubix.inference import optimize_variational_posterior
+
+   vi = optimize_variational_posterior(
+       pipeline=pipe_det,
+       params_init=params_init,
+       static_data=static_data,
+       target=target_cube,
+       learning_rate=5e-3,
+       num_samples=4,
+       beta_kl=1e-3,
+       max_steps=500,
+   )
+
+   posterior_mean = vi.posterior_mean_params
+   posterior_log_std = vi.posterior_log_std_params
+
+
+Performance Notes
+-----------------
+
+For large particle counts, configure optional IFU accumulation controls:
+
+- ``performance.particle_chunk_size``: chunked particle accumulation
+- ``performance.remat_particlewise``: rematerialization/checkpointing of the
+  particle step function for memory/computation tradeoffs
+
+These settings are used by the particlewise IFU builders in ``rubix.core.ifu``.

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -1,0 +1,61 @@
+rubix.inference package
+=======================
+
+Submodules
+----------
+
+rubix.inference.api module
+--------------------------
+
+.. automodule:: rubix.inference.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.modes module
+----------------------------
+
+.. automodule:: rubix.inference.modes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.optimize module
+-------------------------------
+
+.. automodule:: rubix.inference.optimize
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.parameterization module
+---------------------------------------
+
+.. automodule:: rubix.inference.parameterization
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.validation module
+---------------------------------
+
+.. automodule:: rubix.inference.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+rubix.inference.variational module
+----------------------------------
+
+.. automodule:: rubix.inference.variational
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: rubix.inference
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/rubix.rst
+++ b/docs/rubix.rst
@@ -10,6 +10,7 @@ Subpackages
    rubix.core
    rubix.cosmology
    rubix.galaxy
+   rubix.inference
    rubix.pipeline
    rubix.spectra
    rubix.telescope


### PR DESCRIPTION
## Summary
- add dedicated inference workflow guide covering optimization, FD validation, and VI
- add Sphinx API reference page for the new rubix.inference package
- wire inference docs pages into top-level documentation toctrees
- mark PR stack milestones complete in the development plan

## Stack position
PR 8 / 8 in the gradient-production plan