### PR TITLE
feat(inference): add full-IFU cube optimization objective layer

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -37,6 +37,7 @@ Gradient-Based Optimization
 ---------------------------
 
 The standard optimization entrypoint is ``optimize_params``.
+For full-cube fitting with voxel masks/weights, use ``optimize_ifu_cube``.
 
 .. code-block:: python
 
@@ -65,6 +66,22 @@ The standard optimization entrypoint is ``optimize_params``.
    )
 
    optimized = result.params
+
+.. code-block:: python
+
+   from rubix.inference import optimize_ifu_cube
+
+   result = optimize_ifu_cube(
+       pipeline=pipe_det,
+       params_init=params_init,
+       static_data=static_data,
+       target=target_cube,
+       mask=valid_voxel_mask,
+       weights=inverse_variance_weights,
+       normalize_loss=True,
+       learning_rate=1e-2,
+       max_steps=500,
+   )
 
 
 Finite-Difference Gradient Validation

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -28,6 +28,14 @@ rubix.inference.optimize module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.objectives module
+---------------------------------
+
+.. automodule:: rubix.inference.objectives
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.parameterization module
 ---------------------------------------
 

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -2,7 +2,8 @@
 
 from .api import apply_params, forward, loss, value_and_grad
 from .modes import get_pipeline_name_for_mode, make_inference_pipeline
-from .optimize import OptimizationResult, optimize_params
+from .objectives import build_ifu_cube_loss, masked_weighted_mse
+from .optimize import OptimizationResult, optimize_ifu_cube, optimize_params
 from .parameterization import (
     IdentityTransform,
     ParameterTransform,
@@ -36,11 +37,14 @@ __all__ = [
     "finite_difference_grad",
     "forward",
     "get_pipeline_name_for_mode",
+    "build_ifu_cube_loss",
     "inverse_transforms",
     "loss",
     "make_inference_pipeline",
+    "masked_weighted_mse",
     "initialize_mean_field_params",
     "kl_diag_gaussian_to_standard_normal",
+    "optimize_ifu_cube",
     "optimize_variational_posterior",
     "optimize_params",
     "sample_diag_gaussian",

--- a/rubix/inference/objectives.py
+++ b/rubix/inference/objectives.py
@@ -49,15 +49,19 @@ def masked_weighted_mse(
     if mask is not None:
         mask_f = mask.astype(residual_sq.dtype)
         residual_sq = residual_sq * mask_f
-    else:
-        mask_f = jnp.ones_like(residual_sq)
 
     if weights is not None:
         weights_f = weights.astype(residual_sq.dtype)
         residual_sq = residual_sq * weights_f
-        denom = jnp.sum(weights_f * mask_f)
+        if mask is not None:
+            denom = jnp.sum(weights_f * mask_f)
+        else:
+            denom = jnp.sum(weights_f)
     else:
-        denom = jnp.sum(mask_f)
+        if mask is not None:
+            denom = jnp.sum(mask_f)
+        else:
+            denom = jnp.asarray(residual_sq.size, dtype=residual_sq.dtype)
 
     numerator = jnp.sum(residual_sq)
 

--- a/rubix/inference/objectives.py
+++ b/rubix/inference/objectives.py
@@ -1,0 +1,103 @@
+from typing import Optional
+
+import jax.numpy as jnp
+
+from .api import LossFn
+
+
+def masked_weighted_mse(
+    prediction: jnp.ndarray,
+    target: jnp.ndarray,
+    mask: Optional[jnp.ndarray] = None,
+    weights: Optional[jnp.ndarray] = None,
+    normalize: bool = True,
+    eps: float = 1e-12,
+) -> jnp.ndarray:
+    """Compute masked/weighted squared error for IFU cubes.
+
+    Args:
+        prediction (jnp.ndarray): Model prediction cube.
+        target (jnp.ndarray): Target cube with the same shape as ``prediction``.
+        mask (Optional[jnp.ndarray], optional): Binary mask selecting voxels that
+            contribute to the objective. Must have the same shape as ``target``.
+            Defaults to ``None`` (all voxels active).
+        weights (Optional[jnp.ndarray], optional): Per-voxel non-negative weights
+            with the same shape as ``target``. Defaults to ``None``.
+        normalize (bool, optional): If ``True``, divide by the effective weight
+            sum (or number of active voxels if no weights are provided).
+            Defaults to ``True``.
+        eps (float, optional): Numerical floor for normalization denominator.
+            Defaults to 1e-12.
+
+    Raises:
+        ValueError: If input shapes do not match.
+
+    Returns:
+        jnp.ndarray: Scalar weighted squared-error objective.
+    """
+    if prediction.shape != target.shape:
+        raise ValueError("prediction and target must have the same shape")
+
+    if mask is not None and mask.shape != target.shape:
+        raise ValueError("mask must have the same shape as target")
+
+    if weights is not None and weights.shape != target.shape:
+        raise ValueError("weights must have the same shape as target")
+
+    residual_sq = (prediction - target) ** 2
+
+    if mask is not None:
+        mask_f = mask.astype(residual_sq.dtype)
+        residual_sq = residual_sq * mask_f
+    else:
+        mask_f = jnp.ones_like(residual_sq)
+
+    if weights is not None:
+        weights_f = weights.astype(residual_sq.dtype)
+        residual_sq = residual_sq * weights_f
+        denom = jnp.sum(weights_f * mask_f)
+    else:
+        denom = jnp.sum(mask_f)
+
+    numerator = jnp.sum(residual_sq)
+
+    if not normalize:
+        return numerator
+
+    denom = jnp.maximum(denom, jnp.asarray(eps, dtype=residual_sq.dtype))
+    return numerator / denom
+
+
+def build_ifu_cube_loss(
+    mask: Optional[jnp.ndarray] = None,
+    weights: Optional[jnp.ndarray] = None,
+    normalize: bool = True,
+    eps: float = 1e-12,
+) -> LossFn:
+    """Build a reusable IFU-cube loss function with optional mask and weights.
+
+    Args:
+        mask (Optional[jnp.ndarray], optional): Binary voxel selection mask.
+            Defaults to ``None``.
+        weights (Optional[jnp.ndarray], optional): Per-voxel weights.
+            Defaults to ``None``.
+        normalize (bool, optional): Whether to normalize by effective weights.
+            Defaults to ``True``.
+        eps (float, optional): Denominator floor used when normalizing.
+            Defaults to 1e-12.
+
+    Returns:
+        LossFn: Callable ``loss_fn(prediction, target) -> scalar``.
+    """
+
+    def _loss_fn(prediction: jnp.ndarray, target: jnp.ndarray) -> jnp.ndarray:
+        return masked_weighted_mse(
+            prediction=prediction,
+            target=target,
+            mask=mask,
+            weights=weights,
+            normalize=normalize,
+            eps=eps,
+        )
+
+    return _loss_fn

--- a/rubix/inference/optimize.py
+++ b/rubix/inference/optimize.py
@@ -270,12 +270,25 @@ def optimize_ifu_cube(
 
     Raises:
         ValueError: If ``target`` is not a 3D IFU datacube.
+        ValueError: If ``weights`` contains non-finite values.
+        ValueError: If ``weights`` contains negative values.
+        ValueError: If ``mask`` contains negative values.
 
     Returns:
         OptimizationResult: Standard optimization traces and best/final params.
     """
     if target.ndim != 3:
         raise ValueError("target must be a 3D IFU datacube")
+
+    if weights is not None:
+        if not bool(jnp.all(jnp.isfinite(weights))):
+            raise ValueError("weights must be finite")
+        if not bool(jnp.all(weights >= 0)):
+            raise ValueError("weights must be non-negative")
+
+    if mask is not None:
+        if not bool(jnp.all(mask >= 0)):
+            raise ValueError("mask must be non-negative")
 
     cube_loss_fn = build_ifu_cube_loss(
         mask=mask,

--- a/rubix/inference/optimize.py
+++ b/rubix/inference/optimize.py
@@ -9,6 +9,7 @@ from beartype.typing import Any
 from rubix.core.data import RubixData
 
 from .api import LossFn, loss
+from .objectives import build_ifu_cube_loss
 from .parameterization import TransformTree, apply_transforms
 
 ParamsTree = Mapping[str, Mapping[str, Any]]
@@ -224,4 +225,74 @@ def optimize_params(
         final_loss=final_loss_val,
         steps_run=steps_run,
         converged=converged,
+    )
+
+
+def optimize_ifu_cube(
+    pipeline: Any,
+    params_init: ParamsTree,
+    static_data: RubixData,
+    target: jnp.ndarray,
+    mask: Optional[jnp.ndarray] = None,
+    weights: Optional[jnp.ndarray] = None,
+    normalize_loss: bool = True,
+    learning_rate: float = 1e-3,
+    max_steps: int = 500,
+    tol: float = 1e-6,
+    noise_key: Optional[jnp.ndarray] = None,
+    transforms: Optional[TransformTree] = None,
+    optimizer: Optional[optax.GradientTransformation] = None,
+) -> OptimizationResult:
+    """Optimize parameters against a full IFU cube with optional weighting.
+
+    Args:
+        pipeline (Any): Pipeline-like object consumed by :func:`optimize_params`.
+        params_init (ParamsTree): Initial parameters in constrained space.
+        static_data (RubixData): Baseline RubixData passed to the forward model.
+        target (jnp.ndarray): Target IFU datacube.
+        mask (Optional[jnp.ndarray], optional): Optional binary voxel mask with
+            same shape as ``target``. Defaults to ``None``.
+        weights (Optional[jnp.ndarray], optional): Optional per-voxel weights
+            with same shape as ``target``. Defaults to ``None``.
+        normalize_loss (bool, optional): Whether to normalize weighted squared
+            residuals by effective weight sum. Defaults to ``True``.
+        learning_rate (float, optional): Step size for default Adam optimizer.
+            Defaults to 1e-3.
+        max_steps (int, optional): Maximum optimization steps. Defaults to 500.
+        tol (float, optional): Convergence threshold on global update norm.
+            Defaults to 1e-6.
+        noise_key (Optional[jnp.ndarray], optional): Optional key for stochastic
+            pipelines. Defaults to ``None``.
+        transforms (Optional[TransformTree], optional): Optional transform tree
+            for constrained optimization. Defaults to ``None``.
+        optimizer (Optional[optax.GradientTransformation], optional): Custom
+            Optax optimizer. Defaults to ``None`` (Adam with ``learning_rate``).
+
+    Raises:
+        ValueError: If ``target`` is not a 3D IFU datacube.
+
+    Returns:
+        OptimizationResult: Standard optimization traces and best/final params.
+    """
+    if target.ndim != 3:
+        raise ValueError("target must be a 3D IFU datacube")
+
+    cube_loss_fn = build_ifu_cube_loss(
+        mask=mask,
+        weights=weights,
+        normalize=normalize_loss,
+    )
+
+    return optimize_params(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=learning_rate,
+        max_steps=max_steps,
+        tol=tol,
+        loss_fn=cube_loss_fn,
+        noise_key=noise_key,
+        transforms=transforms,
+        optimizer=optimizer,
     )

--- a/tests/test_inference_objectives.py
+++ b/tests/test_inference_objectives.py
@@ -174,7 +174,9 @@ def test_optimize_ifu_cube_with_weights_converges():
 
     # Target: scale=3 -> template*3; only first voxel gets high weight
     target = jnp.full((2, 2, 2), 3.0) * template
-    weights = jnp.zeros((2, 2, 2)).at[0, 0, 0].set(10.0).at[0, 0, 1].set(1.0)
+    weights = jnp.zeros((2, 2, 2))
+    weights = weights.at[0, 0, 0].set(10.0)
+    weights = weights.at[0, 0, 1].set(1.0)
 
     result = optimize_ifu_cube(
         pipeline=pipeline,

--- a/tests/test_inference_objectives.py
+++ b/tests/test_inference_objectives.py
@@ -1,0 +1,113 @@
+import jax.numpy as jnp
+import pytest
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import build_ifu_cube_loss, masked_weighted_mse, optimize_ifu_cube
+
+
+class CubeScalePipeline:
+    """Pipeline that scales a fixed cube template by stars.age[0]."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([0.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_masked_weighted_mse_matches_expected_value():
+    prediction = jnp.array([[[1.0, 3.0], [2.0, 2.0]]])
+    target = jnp.array([[[2.0, 1.0], [2.0, 2.0]]])
+    mask = jnp.array([[[1.0, 0.0], [1.0, 1.0]]])
+    weights = jnp.array([[[2.0, 5.0], [0.5, 1.0]]])
+
+    value = masked_weighted_mse(
+        prediction=prediction,
+        target=target,
+        mask=mask,
+        weights=weights,
+        normalize=True,
+    )
+
+    # Active weighted residual sum: 2*(1^2) + 0.5*(0^2) + 1*(0^2) = 2
+    # Effective weight sum over active voxels: 2 + 0.5 + 1 = 3.5
+    assert jnp.isclose(value, 2.0 / 3.5)
+
+
+def test_ifu_cube_loss_rejects_mask_shape_mismatch():
+    loss_fn = build_ifu_cube_loss(mask=jnp.ones((2, 2, 2)))
+    with pytest.raises(ValueError, match="mask must have the same shape as target"):
+        _ = loss_fn(jnp.ones((1, 2, 2)), jnp.ones((1, 2, 2)))
+
+
+def test_optimize_ifu_cube_uses_mask_to_ignore_unselected_voxels():
+    template = jnp.array(
+        [
+            [[2.0, 1.0], [1.0, 1.0]],
+            [[1.0, 1.0], [1.0, 1.0]],
+        ]
+    )
+    pipeline = CubeScalePipeline(template)
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+
+    # Only one voxel should define the optimum scale: 2*scale ~= 4 -> scale ~= 2.
+    target = jnp.array(
+        [
+            [[4.0, 999.0], [999.0, 999.0]],
+            [[999.0, 999.0], [999.0, 999.0]],
+        ]
+    )
+    mask = jnp.array(
+        [
+            [[1.0, 0.0], [0.0, 0.0]],
+            [[0.0, 0.0], [0.0, 0.0]],
+        ]
+    )
+
+    result = optimize_ifu_cube(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        mask=mask,
+        learning_rate=0.2,
+        max_steps=200,
+        tol=1e-8,
+    )
+
+    assert result.loss_history[0] > result.loss_history[-1]
+    assert abs(float(result.params["stars"]["age"][0]) - 2.0) < 5e-2
+
+
+def test_optimize_ifu_cube_requires_3d_target():
+    pipeline = CubeScalePipeline(jnp.ones((2, 2, 2)))
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+
+    with pytest.raises(ValueError, match="target must be a 3D IFU datacube"):
+        _ = optimize_ifu_cube(
+            pipeline=pipeline,
+            params_init=params_init,
+            static_data=static_data,
+            target=jnp.ones((2, 2)),
+        )

--- a/tests/test_inference_objectives.py
+++ b/tests/test_inference_objectives.py
@@ -111,3 +111,109 @@ def test_optimize_ifu_cube_requires_3d_target():
             static_data=static_data,
             target=jnp.ones((2, 2)),
         )
+
+
+def test_optimize_ifu_cube_rejects_non_finite_weights():
+    pipeline = CubeScalePipeline(jnp.ones((2, 2, 2)))
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+    bad_weights = jnp.array([[[1.0, float("inf")], [1.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]])
+
+    with pytest.raises(ValueError, match="weights must be finite"):
+        _ = optimize_ifu_cube(
+            pipeline=pipeline,
+            params_init=params_init,
+            static_data=static_data,
+            target=jnp.ones((2, 2, 2)),
+            weights=bad_weights,
+        )
+
+
+def test_optimize_ifu_cube_rejects_negative_weights():
+    pipeline = CubeScalePipeline(jnp.ones((2, 2, 2)))
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+    bad_weights = jnp.array([[[-1.0, 1.0], [1.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]])
+
+    with pytest.raises(ValueError, match="weights must be non-negative"):
+        _ = optimize_ifu_cube(
+            pipeline=pipeline,
+            params_init=params_init,
+            static_data=static_data,
+            target=jnp.ones((2, 2, 2)),
+            weights=bad_weights,
+        )
+
+
+def test_optimize_ifu_cube_rejects_negative_mask():
+    pipeline = CubeScalePipeline(jnp.ones((2, 2, 2)))
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+    bad_mask = jnp.array([[[-1.0, 1.0], [1.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]])
+
+    with pytest.raises(ValueError, match="mask must be non-negative"):
+        _ = optimize_ifu_cube(
+            pipeline=pipeline,
+            params_init=params_init,
+            static_data=static_data,
+            target=jnp.ones((2, 2, 2)),
+            mask=bad_mask,
+        )
+
+
+def test_optimize_ifu_cube_with_weights_converges():
+    template = jnp.array(
+        [
+            [[2.0, 1.0], [1.0, 1.0]],
+            [[1.0, 1.0], [1.0, 1.0]],
+        ]
+    )
+    pipeline = CubeScalePipeline(template)
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.5])}}
+
+    # Target: scale=3 -> template*3; only first voxel gets high weight
+    target = jnp.full((2, 2, 2), 3.0) * template
+    weights = jnp.zeros((2, 2, 2)).at[0, 0, 0].set(10.0).at[0, 0, 1].set(1.0)
+
+    result = optimize_ifu_cube(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        weights=weights,
+        normalize_loss=True,
+        learning_rate=0.1,
+        max_steps=300,
+        tol=1e-8,
+    )
+
+    assert result.loss_history[0] > result.loss_history[-1]
+    assert abs(float(result.params["stars"]["age"][0]) - 3.0) < 0.1
+
+
+def test_optimize_ifu_cube_normalize_loss_false_converges():
+    template = jnp.array(
+        [
+            [[1.0, 1.0], [1.0, 1.0]],
+            [[1.0, 1.0], [1.0, 1.0]],
+        ]
+    )
+    pipeline = CubeScalePipeline(template)
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.5])}}
+    target = 2.5 * template
+
+    result = optimize_ifu_cube(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        normalize_loss=False,
+        learning_rate=0.01,
+        max_steps=600,
+        tol=1e-8,
+    )
+
+    assert result.loss_history[0] > result.loss_history[-1]
+    assert abs(float(result.params["stars"]["age"][0]) - 2.5) < 0.1


### PR DESCRIPTION
## Summary
- add reusable IFU objective helpers in rubix.inference.objectives
- add optimize_ifu_cube wrapper that uses masked/weighted IFU cube losses
- export new APIs via rubix.inference package init
- add objective + integration unit tests
- document new objective module and optimize_ifu_cube usage

## Validation
- pre-commit run on changed files passed (black, isort, pydoclint)
- compileall passed for new/updated inference modules and tests

## Notes
- pytest execution in the local rubix conda environment did not return output in this sandbox session, so I validated with hooks + compile checks and included focused tests in this PR