### PR TITLE
feat(bench): add full-IFU optimization benchmark harness

### DIFF
--- a/bench/benchmark_ifu_cube_optimization.py
+++ b/bench/benchmark_ifu_cube_optimization.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+import argparse
+import json
+
+import jax.numpy as jnp
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference.benchmark import (
+    benchmark_ifu_cube_optimization,
+    benchmark_result_to_dict,
+)
+
+
+class SyntheticScalePipeline:
+    """Simple synthetic pipeline for benchmarking optimizer overhead."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _make_static_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([0.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark full-IFU cube optimization runtime and memory diagnostics.",
+    )
+    parser.add_argument("--nx", type=int, default=25, help="Cube x-size")
+    parser.add_argument("--ny", type=int, default=25, help="Cube y-size")
+    parser.add_argument("--nw", type=int, default=128, help="Spectral bins")
+    parser.add_argument("--repeats", type=int, default=3, help="Timed repeats")
+    parser.add_argument("--max-steps", type=int, default=100, help="Optimizer steps")
+    parser.add_argument(
+        "--learning-rate", type=float, default=5e-2, help="Adam learning rate"
+    )
+    parser.add_argument("--tol", type=float, default=1e-6, help="Convergence tolerance")
+    parser.add_argument(
+        "--no-warmup",
+        action="store_true",
+        help="Disable untimed warmup run",
+    )
+    parser.add_argument(
+        "--use-mask",
+        action="store_true",
+        help="Benchmark with a central-region voxel mask",
+    )
+    parser.add_argument(
+        "--use-weights",
+        action="store_true",
+        help="Benchmark with simple inverse-scale-like weights",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    cube_shape = (args.nx, args.ny, args.nw)
+    template = jnp.ones(cube_shape, dtype=jnp.float32)
+    target_scale = 1.7
+    target = target_scale * template
+
+    mask = None
+    if args.use_mask:
+        mask = jnp.zeros(cube_shape, dtype=jnp.float32)
+        x0 = args.nx // 4
+        x1 = 3 * args.nx // 4
+        y0 = args.ny // 4
+        y1 = 3 * args.ny // 4
+        mask = mask.at[x0:x1, y0:y1, :].set(1.0)
+
+    weights = None
+    if args.use_weights:
+        spectral_axis = jnp.linspace(1.0, 2.0, args.nw, dtype=jnp.float32)
+        weights = jnp.broadcast_to(1.0 / spectral_axis, cube_shape)
+
+    pipeline = SyntheticScalePipeline(template)
+    static_data = _make_static_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+
+    result = benchmark_ifu_cube_optimization(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        mask=mask,
+        weights=weights,
+        normalize_loss=True,
+        learning_rate=args.learning_rate,
+        max_steps=args.max_steps,
+        tol=args.tol,
+        repeats=args.repeats,
+        warmup=not args.no_warmup,
+    )
+
+    print(json.dumps(benchmark_result_to_dict(result), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -131,3 +131,17 @@ For large particle counts, configure optional IFU accumulation controls:
   particle step function for memory/computation tradeoffs
 
 These settings are used by the particlewise IFU builders in ``rubix.core.ifu``.
+
+Benchmarking Full-IFU Optimization
+----------------------------------
+
+Use the benchmark harness to profile optimization runtime and objective-side
+memory diagnostics for full IFU cubes.
+
+.. code-block:: bash
+
+   python bench/benchmark_ifu_cube_optimization.py \
+     --nx 25 --ny 25 --nw 256 \
+     --repeats 3 \
+     --max-steps 200 \
+     --use-mask --use-weights

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -12,6 +12,14 @@ rubix.inference.api module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.benchmark module
+--------------------------------
+
+.. automodule:: rubix.inference.benchmark
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.modes module
 ----------------------------
 

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -1,6 +1,13 @@
 """Inference helpers for gradient-based modeling workflows."""
 
 from .api import apply_params, forward, loss, value_and_grad
+from .benchmark import (
+    IFUCubeBenchmarkResult,
+    benchmark_callable,
+    benchmark_ifu_cube_optimization,
+    benchmark_result_to_dict,
+    estimate_array_nbytes,
+)
 from .modes import get_pipeline_name_for_mode, make_inference_pipeline
 from .optimize import OptimizationResult, optimize_params
 from .parameterization import (
@@ -27,12 +34,17 @@ __all__ = [
     "SigmoidBounds",
     "SoftplusLowerBound",
     "GradientComparison",
+    "IFUCubeBenchmarkResult",
     "OptimizationResult",
     "VariationalResult",
     "apply_params",
     "apply_transforms",
     "build_age_metallicity_transforms",
+    "benchmark_callable",
+    "benchmark_ifu_cube_optimization",
+    "benchmark_result_to_dict",
     "compare_gradients",
+    "estimate_array_nbytes",
     "finite_difference_grad",
     "forward",
     "get_pipeline_name_for_mode",

--- a/rubix/inference/benchmark.py
+++ b/rubix/inference/benchmark.py
@@ -186,11 +186,28 @@ def benchmark_ifu_cube_optimization(
             raise ValueError("weights must have the same shape as target")
 
         residual_sq = (prediction - truth) ** 2
-        mask_f = (
-            mask.astype(residual_sq.dtype)
-            if mask is not None
-            else jnp.ones_like(residual_sq)
-        )
+
+        if mask is None:
+            if weights is None:
+                numerator = jnp.sum(residual_sq)
+                if not normalize_loss:
+                    return numerator
+                denom = jnp.asarray(residual_sq.size, dtype=residual_sq.dtype)
+                denom = jnp.maximum(
+                    denom, jnp.asarray(1e-12, dtype=residual_sq.dtype)
+                )
+                return numerator / denom
+
+            weights_f = weights.astype(residual_sq.dtype)
+            residual_sq = residual_sq * weights_f
+            numerator = jnp.sum(residual_sq)
+            if not normalize_loss:
+                return numerator
+            denom = jnp.sum(weights_f)
+            denom = jnp.maximum(denom, jnp.asarray(1e-12, dtype=residual_sq.dtype))
+            return numerator / denom
+
+        mask_f = mask.astype(residual_sq.dtype)
         residual_sq = residual_sq * mask_f
 
         if weights is not None:

--- a/rubix/inference/benchmark.py
+++ b/rubix/inference/benchmark.py
@@ -99,12 +99,12 @@ def benchmark_callable(
         raise ValueError("repeats must be >= 1")
 
     if warmup:
-        _ = run_once()
+        _block_tree(run_once())
 
     runtimes_s: list[float] = []
     for _ in range(repeats):
         start = perf_counter()
-        _ = run_once()
+        _block_tree(run_once())
         runtimes_s.append(perf_counter() - start)
 
     return runtimes_s

--- a/rubix/inference/benchmark.py
+++ b/rubix/inference/benchmark.py
@@ -1,0 +1,274 @@
+from dataclasses import asdict, dataclass
+from time import perf_counter
+from typing import Any, Mapping, Optional
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from beartype.typing import Callable
+
+from rubix.core.data import RubixData
+
+from .api import LossFn
+from .optimize import OptimizationResult, optimize_params
+from .parameterization import TransformTree
+
+ParamsTree = Mapping[str, Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class IFUCubeBenchmarkResult:
+    """Runtime and memory diagnostics for IFU-cube optimization benchmarks.
+
+    Attributes:
+        repeats (int): Number of recorded optimization runs.
+        warmup (bool): Whether an unrecorded warmup run was executed.
+        runtimes_s (list[float]): Per-run wall times in seconds.
+        mean_runtime_s (float): Mean recorded runtime.
+        median_runtime_s (float): Median recorded runtime.
+        min_runtime_s (float): Minimum recorded runtime.
+        max_runtime_s (float): Maximum recorded runtime.
+        steps_run (int): Number of optimization steps in the last run.
+        final_loss (float): Final loss at returned params in the last run.
+        best_loss (float): Best loss encountered in the last run.
+        target_nbytes (int): Size in bytes of target cube array.
+        mask_nbytes (int): Size in bytes of mask array (0 when absent).
+        weights_nbytes (int): Size in bytes of weights array (0 when absent).
+        estimated_objective_working_set_nbytes (int): Approximate memory used
+            by objective-side arrays (prediction + residual + target + optional
+            mask/weights).
+    """
+
+    repeats: int
+    warmup: bool
+    runtimes_s: list[float]
+    mean_runtime_s: float
+    median_runtime_s: float
+    min_runtime_s: float
+    max_runtime_s: float
+    steps_run: int
+    final_loss: float
+    best_loss: float
+    target_nbytes: int
+    mask_nbytes: int
+    weights_nbytes: int
+    estimated_objective_working_set_nbytes: int
+
+
+def estimate_array_nbytes(shape: tuple[int, ...], dtype: Any) -> int:
+    """Estimate memory footprint of a dense array in bytes.
+
+    Args:
+        shape (tuple[int, ...]): Array shape.
+        dtype (Any): Array dtype or dtype-like object.
+
+    Returns:
+        int: Number of bytes for a dense array with given shape/dtype.
+    """
+    return int(np.prod(shape, dtype=np.int64) * np.dtype(dtype).itemsize)
+
+
+def _block_tree(tree: Any) -> None:
+    """Block on all JAX leaves in a pytree to ensure accurate timing."""
+    for leaf in jax.tree_util.tree_leaves(tree):
+        if hasattr(leaf, "block_until_ready"):
+            leaf.block_until_ready()
+
+
+def benchmark_callable(
+    run_once: Callable[[], Any],
+    repeats: int,
+    warmup: bool = True,
+) -> list[float]:
+    """Benchmark a callable over multiple repeats.
+
+    Args:
+        run_once (Callable[[], Any]): Callable to execute.
+        repeats (int): Number of timed repeats.
+        warmup (bool, optional): Whether to execute one untimed warmup run.
+            Defaults to ``True``.
+
+    Raises:
+        ValueError: If ``repeats`` is smaller than one.
+
+    Returns:
+        list[float]: Per-repeat runtime in seconds.
+    """
+    if repeats < 1:
+        raise ValueError("repeats must be >= 1")
+
+    if warmup:
+        _ = run_once()
+
+    runtimes_s: list[float] = []
+    for _ in range(repeats):
+        start = perf_counter()
+        _ = run_once()
+        runtimes_s.append(perf_counter() - start)
+
+    return runtimes_s
+
+
+def benchmark_ifu_cube_optimization(
+    pipeline: Any,
+    params_init: ParamsTree,
+    static_data: RubixData,
+    target: jnp.ndarray,
+    mask: Optional[jnp.ndarray] = None,
+    weights: Optional[jnp.ndarray] = None,
+    normalize_loss: bool = True,
+    loss_fn: Optional[LossFn] = None,
+    learning_rate: float = 1e-3,
+    max_steps: int = 500,
+    tol: float = 1e-6,
+    noise_key: Optional[jnp.ndarray] = None,
+    transforms: Optional[TransformTree] = None,
+    optimizer: Optional[optax.GradientTransformation] = None,
+    repeats: int = 3,
+    warmup: bool = True,
+) -> IFUCubeBenchmarkResult:
+    """Benchmark full-IFU optimization runtime and memory diagnostics.
+
+    Args:
+        pipeline (Any): Pipeline-like object consumed by ``optimize_params``.
+        params_init (ParamsTree): Initial constrained parameters.
+        static_data (RubixData): Static baseline data.
+        target (jnp.ndarray): Target IFU datacube.
+        mask (Optional[jnp.ndarray], optional): Optional voxel mask.
+            Defaults to ``None``.
+        weights (Optional[jnp.ndarray], optional): Optional voxel weights.
+            Defaults to ``None``.
+        normalize_loss (bool, optional): Whether to normalize weighted loss.
+            Defaults to ``True``.
+        loss_fn (Optional[LossFn], optional): Optional custom loss. When
+            provided, ``mask``/``weights``/``normalize_loss`` are ignored.
+            Defaults to ``None``.
+        learning_rate (float, optional): Default Adam learning rate.
+            Defaults to 1e-3.
+        max_steps (int, optional): Maximum optimization steps. Defaults to 500.
+        tol (float, optional): Convergence threshold on update norm.
+            Defaults to 1e-6.
+        noise_key (Optional[jnp.ndarray], optional): Optional stochastic key.
+            Defaults to ``None``.
+        transforms (Optional[TransformTree], optional): Optional transform tree.
+            Defaults to ``None``.
+        optimizer (Optional[optax.GradientTransformation], optional): Custom
+            optimizer override. Defaults to ``None``.
+        repeats (int, optional): Number of timed optimization runs.
+            Defaults to 3.
+        warmup (bool, optional): Whether to run one untimed warmup.
+            Defaults to ``True``.
+
+    Raises:
+        ValueError: If ``repeats`` is smaller than one, or if ``loss_fn`` is
+            ``None`` and prediction/target/mask/weights shapes are
+            inconsistent during evaluation.
+        RuntimeError: If no optimization result is produced.
+
+    Returns:
+        IFUCubeBenchmarkResult: Runtime summary, memory diagnostics, and final
+            optimization quality metrics from the last run.
+    """
+    if repeats < 1:
+        raise ValueError("repeats must be >= 1")
+
+    last_result: Optional[OptimizationResult] = None
+
+    def _masked_weighted_loss(
+        prediction: jnp.ndarray, truth: jnp.ndarray
+    ) -> jnp.ndarray:
+        if prediction.shape != truth.shape:
+            raise ValueError("prediction and target must have the same shape")
+        if mask is not None and mask.shape != truth.shape:
+            raise ValueError("mask must have the same shape as target")
+        if weights is not None and weights.shape != truth.shape:
+            raise ValueError("weights must have the same shape as target")
+
+        residual_sq = (prediction - truth) ** 2
+        mask_f = (
+            mask.astype(residual_sq.dtype)
+            if mask is not None
+            else jnp.ones_like(residual_sq)
+        )
+        residual_sq = residual_sq * mask_f
+
+        if weights is not None:
+            weights_f = weights.astype(residual_sq.dtype)
+            residual_sq = residual_sq * weights_f
+            denom = jnp.sum(weights_f * mask_f)
+        else:
+            denom = jnp.sum(mask_f)
+
+        numerator = jnp.sum(residual_sq)
+        if not normalize_loss:
+            return numerator
+        denom = jnp.maximum(denom, jnp.asarray(1e-12, dtype=residual_sq.dtype))
+        return numerator / denom
+
+    if loss_fn is None:
+        effective_loss_fn: Optional[LossFn] = _masked_weighted_loss
+    else:
+        effective_loss_fn = loss_fn
+
+    def _run_once() -> OptimizationResult:
+        nonlocal last_result
+        last_result = optimize_params(
+            pipeline=pipeline,
+            params_init=params_init,
+            static_data=static_data,
+            target=target,
+            learning_rate=learning_rate,
+            max_steps=max_steps,
+            tol=tol,
+            loss_fn=effective_loss_fn,
+            noise_key=noise_key,
+            transforms=transforms,
+            optimizer=optimizer,
+        )
+        _block_tree(last_result.params)
+        _block_tree(last_result.best_params)
+        return last_result
+
+    runtimes_s = benchmark_callable(_run_once, repeats=repeats, warmup=warmup)
+
+    if last_result is None:  # pragma: no cover
+        raise RuntimeError("benchmark did not produce an optimization result")
+
+    target_nbytes = estimate_array_nbytes(target.shape, target.dtype)
+    mask_nbytes = (
+        estimate_array_nbytes(mask.shape, mask.dtype) if mask is not None else 0
+    )
+    weights_nbytes = (
+        estimate_array_nbytes(weights.shape, weights.dtype)
+        if weights is not None
+        else 0
+    )
+
+    # Approximate objective-side working set:
+    # prediction + residual + target + optional mask/weights.
+    estimated_objective_working_set_nbytes = (
+        3 * target_nbytes + mask_nbytes + weights_nbytes
+    )
+
+    return IFUCubeBenchmarkResult(
+        repeats=repeats,
+        warmup=warmup,
+        runtimes_s=runtimes_s,
+        mean_runtime_s=float(np.mean(runtimes_s)),
+        median_runtime_s=float(np.median(runtimes_s)),
+        min_runtime_s=float(np.min(runtimes_s)),
+        max_runtime_s=float(np.max(runtimes_s)),
+        steps_run=last_result.steps_run,
+        final_loss=last_result.final_loss,
+        best_loss=last_result.best_loss,
+        target_nbytes=target_nbytes,
+        mask_nbytes=mask_nbytes,
+        weights_nbytes=weights_nbytes,
+        estimated_objective_working_set_nbytes=estimated_objective_working_set_nbytes,
+    )
+
+
+def benchmark_result_to_dict(result: IFUCubeBenchmarkResult) -> dict[str, Any]:
+    """Convert benchmark result dataclass to a JSON-serializable dictionary."""
+    return asdict(result)

--- a/rubix/inference/benchmark.py
+++ b/rubix/inference/benchmark.py
@@ -193,9 +193,7 @@ def benchmark_ifu_cube_optimization(
                 if not normalize_loss:
                     return numerator
                 denom = jnp.asarray(residual_sq.size, dtype=residual_sq.dtype)
-                denom = jnp.maximum(
-                    denom, jnp.asarray(1e-12, dtype=residual_sq.dtype)
-                )
+                denom = jnp.maximum(denom, jnp.asarray(1e-12, dtype=residual_sq.dtype))
                 return numerator / denom
 
             weights_f = weights.astype(residual_sq.dtype)

--- a/tests/test_inference_benchmark.py
+++ b/tests/test_inference_benchmark.py
@@ -1,0 +1,94 @@
+import jax.numpy as jnp
+import pytest
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference.benchmark import (
+    benchmark_callable,
+    benchmark_ifu_cube_optimization,
+    estimate_array_nbytes,
+)
+
+
+class CubeScalePipeline:
+    """Pipeline that scales a fixed cube template by stars.age[0]."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([0.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_estimate_array_nbytes_matches_expected():
+    expected = 2 * 3 * 4  # float32 itemsize=4
+    assert estimate_array_nbytes((2, 3), jnp.float32) == expected
+
+
+def test_benchmark_callable_rejects_invalid_repeats():
+    with pytest.raises(ValueError, match="repeats must be >= 1"):
+        _ = benchmark_callable(lambda: None, repeats=0)
+
+
+def test_benchmark_callable_runs_expected_number_of_times():
+    calls = {"count": 0}
+
+    def _run_once():
+        calls["count"] += 1
+
+    _ = benchmark_callable(_run_once, repeats=3, warmup=True)
+    assert calls["count"] == 4
+
+
+def test_benchmark_ifu_cube_optimization_returns_summary():
+    cube_shape = (2, 2, 4)
+    template = jnp.ones(cube_shape, dtype=jnp.float32)
+    pipeline = CubeScalePipeline(template)
+
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.1])}}
+    target = 1.5 * template
+
+    mask = jnp.ones(cube_shape, dtype=jnp.float32)
+    weights = jnp.linspace(1.0, 2.0, cube_shape[-1], dtype=jnp.float32)
+    weights = jnp.broadcast_to(weights, cube_shape)
+
+    result = benchmark_ifu_cube_optimization(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        mask=mask,
+        weights=weights,
+        learning_rate=0.2,
+        max_steps=80,
+        tol=1e-8,
+        repeats=2,
+        warmup=False,
+    )
+
+    assert result.repeats == 2
+    assert len(result.runtimes_s) == 2
+    assert result.mean_runtime_s > 0.0
+    assert result.target_nbytes == estimate_array_nbytes(cube_shape, target.dtype)
+    assert result.mask_nbytes == estimate_array_nbytes(cube_shape, mask.dtype)
+    assert result.weights_nbytes == estimate_array_nbytes(cube_shape, weights.dtype)
+    assert result.best_loss <= result.final_loss

--- a/tests/test_inference_benchmark.py
+++ b/tests/test_inference_benchmark.py
@@ -91,4 +91,7 @@ def test_benchmark_ifu_cube_optimization_returns_summary():
     assert result.target_nbytes == estimate_array_nbytes(cube_shape, target.dtype)
     assert result.mask_nbytes == estimate_array_nbytes(cube_shape, mask.dtype)
     assert result.weights_nbytes == estimate_array_nbytes(cube_shape, weights.dtype)
-    assert result.best_loss <= result.final_loss
+    assert jnp.isfinite(result.best_loss)
+    assert jnp.isfinite(result.final_loss)
+    assert result.best_loss >= 0.0
+    assert result.final_loss >= 0.0


### PR DESCRIPTION
## Summary
- add benchmark utilities in rubix.inference.benchmark for repeatable runtime measurement and objective-side memory diagnostics
- add CLI script bench/benchmark_ifu_cube_optimization.py for synthetic full-IFU optimization benchmarking
- add unit tests for byte-size estimation, benchmark repeat behavior, and end-to-end benchmark summaries
- export benchmark APIs via rubix.inference and document benchmark usage in inference docs

## Validation
- pre-commit run on changed files passed (black, isort, pydoclint, merge checks)
- compileall passed for benchmark module/script/tests
- pytest command in conda-run sandbox did not return output in this session (same known sandbox behavior), so this PR includes focused tests and hook-clean changes