### PR TITLE
feat(inference): add composable science loss library for IFU fitting

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -67,6 +67,33 @@ The standard optimization entrypoint is ``optimize_params``.
    optimized = result.params
 
 
+Science Loss Functions
+----------------------
+
+Rubix provides reusable loss builders for robust and probabilistic IFU fitting.
+
+.. code-block:: python
+
+   from rubix.inference import combine_loss_fns, huber_data_loss, masked_gaussian_nll
+
+   def gaussian_term(pred, target):
+       return masked_gaussian_nll(
+           pred,
+           target,
+           inv_variance=inverse_variance_cube,
+           mask=valid_voxel_mask,
+           normalize=True,
+       )
+
+   def robust_term(pred, target):
+       return huber_data_loss(pred, target, delta=0.2, mask=valid_voxel_mask)
+
+   loss_fn = combine_loss_fns(
+       [gaussian_term, robust_term],
+       weights=[1.0, 0.1],
+   )
+
+
 Finite-Difference Gradient Validation
 -------------------------------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -12,6 +12,14 @@ rubix.inference.api module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.losses module
+-----------------------------
+
+.. automodule:: rubix.inference.losses
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.modes module
 ----------------------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -19,7 +19,7 @@ rubix.inference.losses module
    :members:
    :undoc-members:
    :show-inheritance:
-   
+
 rubix.inference.benchmark module
 --------------------------------
 

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -1,7 +1,6 @@
 """Inference helpers for gradient-based modeling workflows."""
 
 from .api import apply_params, forward, loss, value_and_grad
-from .losses import combine_loss_fns, huber_data_loss, masked_gaussian_nll
 from .benchmark import (
     IFUCubeBenchmarkResult,
     benchmark_callable,
@@ -9,6 +8,7 @@ from .benchmark import (
     benchmark_result_to_dict,
     estimate_array_nbytes,
 )
+from .losses import combine_loss_fns, huber_data_loss, masked_gaussian_nll
 from .modes import get_pipeline_name_for_mode, make_inference_pipeline
 from .objectives import build_ifu_cube_loss, masked_weighted_mse
 from .optimize import OptimizationResult, optimize_ifu_cube, optimize_params

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -1,6 +1,7 @@
 """Inference helpers for gradient-based modeling workflows."""
 
 from .api import apply_params, forward, loss, value_and_grad
+from .losses import combine_loss_fns, huber_data_loss, masked_gaussian_nll
 from .modes import get_pipeline_name_for_mode, make_inference_pipeline
 from .optimize import OptimizationResult, optimize_params
 from .parameterization import (
@@ -32,13 +33,16 @@ __all__ = [
     "apply_params",
     "apply_transforms",
     "build_age_metallicity_transforms",
+    "combine_loss_fns",
     "compare_gradients",
     "finite_difference_grad",
     "forward",
     "get_pipeline_name_for_mode",
+    "huber_data_loss",
     "inverse_transforms",
     "loss",
     "make_inference_pipeline",
+    "masked_gaussian_nll",
     "initialize_mean_field_params",
     "kl_diag_gaussian_to_standard_normal",
     "optimize_variational_posterior",

--- a/rubix/inference/losses.py
+++ b/rubix/inference/losses.py
@@ -1,0 +1,192 @@
+from typing import Optional, Sequence
+
+import jax.numpy as jnp
+
+from .api import LossFn
+
+
+def masked_gaussian_nll(
+    prediction: jnp.ndarray,
+    target: jnp.ndarray,
+    sigma: Optional[jnp.ndarray] = None,
+    inv_variance: Optional[jnp.ndarray] = None,
+    mask: Optional[jnp.ndarray] = None,
+    normalize: bool = True,
+    eps: float = 1e-12,
+) -> jnp.ndarray:
+    """Compute masked Gaussian negative log-likelihood for cube residuals.
+
+    Args:
+        prediction (jnp.ndarray): Predicted IFU cube.
+        target (jnp.ndarray): Target IFU cube with the same shape.
+        sigma (Optional[jnp.ndarray], optional): Per-voxel Gaussian standard
+            deviation. Must match ``target`` shape when provided.
+            Defaults to ``None``.
+        inv_variance (Optional[jnp.ndarray], optional): Per-voxel inverse
+            variance. Must match ``target`` shape when provided.
+            Defaults to ``None``.
+        mask (Optional[jnp.ndarray], optional): Binary selection mask with same
+            shape as ``target``. Defaults to ``None``.
+        normalize (bool, optional): If ``True``, divide by number of active
+            voxels. Defaults to ``True``.
+        eps (float, optional): Numerical floor for log/denominator safety.
+            Defaults to 1e-12.
+
+    Raises:
+        ValueError: If array shapes are inconsistent or both ``sigma`` and
+            ``inv_variance`` are provided.
+
+    Returns:
+        jnp.ndarray: Scalar Gaussian NLL.
+    """
+    if prediction.shape != target.shape:
+        raise ValueError("prediction and target must have the same shape")
+
+    if sigma is not None and sigma.shape != target.shape:
+        raise ValueError("sigma must have the same shape as target")
+
+    if inv_variance is not None and inv_variance.shape != target.shape:
+        raise ValueError("inv_variance must have the same shape as target")
+
+    if mask is not None and mask.shape != target.shape:
+        raise ValueError("mask must have the same shape as target")
+
+    if sigma is not None and inv_variance is not None:
+        raise ValueError("provide only one of sigma or inv_variance")
+
+    residual = prediction - target
+    dtype = residual.dtype
+    eps_arr = jnp.asarray(eps, dtype=dtype)
+
+    if inv_variance is not None:
+        precision = jnp.maximum(inv_variance.astype(dtype), eps_arr)
+        log_variance = -jnp.log(precision)
+    elif sigma is not None:
+        sigma_safe = jnp.maximum(sigma.astype(dtype), eps_arr)
+        variance = sigma_safe**2
+        precision = 1.0 / variance
+        log_variance = jnp.log(variance)
+    else:
+        precision = jnp.ones_like(residual)
+        log_variance = jnp.zeros_like(residual)
+
+    per_voxel_nll = 0.5 * (residual**2 * precision + log_variance)
+
+    if mask is None:
+        mask_f = jnp.ones_like(per_voxel_nll)
+    else:
+        mask_f = mask.astype(dtype)
+
+    total_nll = jnp.sum(per_voxel_nll * mask_f)
+
+    if not normalize:
+        return total_nll
+
+    denom = jnp.maximum(jnp.sum(mask_f), eps_arr)
+    return total_nll / denom
+
+
+def huber_data_loss(
+    prediction: jnp.ndarray,
+    target: jnp.ndarray,
+    delta: float = 1.0,
+    mask: Optional[jnp.ndarray] = None,
+    weights: Optional[jnp.ndarray] = None,
+    normalize: bool = True,
+    eps: float = 1e-12,
+) -> jnp.ndarray:
+    """Compute masked and weighted Huber loss on IFU cube residuals.
+
+    Args:
+        prediction (jnp.ndarray): Predicted IFU cube.
+        target (jnp.ndarray): Target IFU cube with same shape as prediction.
+        delta (float, optional): Huber transition threshold. Defaults to 1.0.
+        mask (Optional[jnp.ndarray], optional): Optional voxel mask.
+            Defaults to ``None``.
+        weights (Optional[jnp.ndarray], optional): Optional per-voxel weights.
+            Defaults to ``None``.
+        normalize (bool, optional): If ``True``, divide by effective weighted
+            mask sum. Defaults to ``True``.
+        eps (float, optional): Denominator floor. Defaults to 1e-12.
+
+    Raises:
+        ValueError: If array shapes are inconsistent.
+
+    Returns:
+        jnp.ndarray: Scalar Huber loss.
+    """
+    if prediction.shape != target.shape:
+        raise ValueError("prediction and target must have the same shape")
+
+    if mask is not None and mask.shape != target.shape:
+        raise ValueError("mask must have the same shape as target")
+
+    if weights is not None and weights.shape != target.shape:
+        raise ValueError("weights must have the same shape as target")
+
+    residual = prediction - target
+    abs_residual = jnp.abs(residual)
+    delta_arr = jnp.asarray(delta, dtype=residual.dtype)
+
+    quadratic = 0.5 * residual**2
+    linear = delta_arr * (abs_residual - 0.5 * delta_arr)
+    huber = jnp.where(abs_residual <= delta_arr, quadratic, linear)
+
+    if mask is None:
+        mask_f = jnp.ones_like(huber)
+    else:
+        mask_f = mask.astype(huber.dtype)
+
+    if weights is None:
+        weights_f = jnp.ones_like(huber)
+    else:
+        weights_f = weights.astype(huber.dtype)
+
+    weighted = huber * mask_f * weights_f
+    total = jnp.sum(weighted)
+
+    if not normalize:
+        return total
+
+    denom = jnp.maximum(
+        jnp.sum(mask_f * weights_f),
+        jnp.asarray(eps, dtype=huber.dtype),
+    )
+    return total / denom
+
+
+def combine_loss_fns(
+    loss_fns: Sequence[LossFn],
+    weights: Optional[Sequence[float]] = None,
+) -> LossFn:
+    """Combine multiple prediction-target losses into one scalar objective.
+
+    Args:
+        loss_fns (Sequence[LossFn]): Individual loss callables.
+        weights (Optional[Sequence[float]], optional): Optional scalar weights
+            with same length as ``loss_fns``. Defaults to equal weighting.
+
+    Raises:
+        ValueError: If no losses are provided or weight lengths mismatch.
+
+    Returns:
+        LossFn: Combined loss function.
+    """
+    if len(loss_fns) == 0:
+        raise ValueError("loss_fns must contain at least one loss function")
+
+    if weights is None:
+        coeffs = [1.0] * len(loss_fns)
+    else:
+        if len(weights) != len(loss_fns):
+            raise ValueError("weights must have the same length as loss_fns")
+        coeffs = list(weights)
+
+    def _combined(prediction: jnp.ndarray, target: jnp.ndarray) -> jnp.ndarray:
+        values = [
+            jnp.asarray(c, dtype=prediction.dtype) * fn(prediction, target)
+            for c, fn in zip(coeffs, loss_fns)
+        ]
+        return sum(values)
+
+    return _combined

--- a/rubix/inference/losses.py
+++ b/rubix/inference/losses.py
@@ -110,11 +110,15 @@ def huber_data_loss(
         eps (float, optional): Denominator floor. Defaults to 1e-12.
 
     Raises:
-        ValueError: If array shapes are inconsistent.
+        ValueError: If ``delta`` is not strictly positive or array shapes are
+            inconsistent.
 
     Returns:
         jnp.ndarray: Scalar Huber loss.
     """
+    if delta <= 0:
+        raise ValueError("delta must be strictly positive")
+
     if prediction.shape != target.shape:
         raise ValueError("prediction and target must have the same shape")
 

--- a/tests/test_inference_losses.py
+++ b/tests/test_inference_losses.py
@@ -68,6 +68,17 @@ def test_masked_gaussian_nll_rejects_ambiguous_uncertainty_inputs():
         )
 
 
+def test_huber_data_loss_rejects_non_positive_delta():
+    prediction = jnp.ones((1, 1, 1))
+    target = jnp.ones((1, 1, 1))
+
+    with pytest.raises(ValueError, match="delta must be strictly positive"):
+        huber_data_loss(prediction, target, delta=0.0)
+
+    with pytest.raises(ValueError, match="delta must be strictly positive"):
+        huber_data_loss(prediction, target, delta=-1.0)
+
+
 def test_huber_data_loss_reduces_outlier_sensitivity_vs_quadratic():
     prediction = jnp.array([[[10.0]]])
     target = jnp.array([[[0.0]]])
@@ -118,4 +129,5 @@ def test_composed_loss_works_with_optimize_params():
     )
 
     assert result.loss_history[0] > result.loss_history[-1]
-    assert result.best_loss <= result.final_loss
+    assert jnp.allclose(result.best_loss, jnp.min(result.loss_history))
+    assert result.final_loss < result.loss_history[0]

--- a/tests/test_inference_losses.py
+++ b/tests/test_inference_losses.py
@@ -1,0 +1,121 @@
+import jax.numpy as jnp
+import pytest
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import combine_loss_fns, huber_data_loss, masked_gaussian_nll
+from rubix.inference.optimize import optimize_params
+
+
+class DummyPipeline:
+    """Simple differentiable pipeline used for inference loss tests."""
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        value = jnp.sum(rubixdata.stars.age) + 2.0 * jnp.sum(
+            rubixdata.stars.metallicity
+        )
+        return jnp.reshape(value, (1, 1, 1))
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([1.0]),
+            metallicity=jnp.array([0.1]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_masked_gaussian_nll_matches_expected_value():
+    prediction = jnp.array([[[2.0, 1.0]]])
+    target = jnp.array([[[1.0, 1.0]]])
+    inv_variance = jnp.array([[[4.0, 1.0]]])
+    mask = jnp.array([[[1.0, 0.0]]])
+
+    value = masked_gaussian_nll(
+        prediction=prediction,
+        target=target,
+        inv_variance=inv_variance,
+        mask=mask,
+        normalize=True,
+    )
+
+    # Active term: 0.5 * (1^2 * 4 - log(4))
+    expected = 0.5 * (4.0 - jnp.log(4.0))
+    assert jnp.allclose(value, expected)
+
+
+def test_masked_gaussian_nll_rejects_ambiguous_uncertainty_inputs():
+    prediction = jnp.ones((1, 1, 1))
+    target = jnp.ones((1, 1, 1))
+    sigma = jnp.ones((1, 1, 1))
+    inv_variance = jnp.ones((1, 1, 1))
+
+    with pytest.raises(ValueError, match="provide only one of sigma or inv_variance"):
+        _ = masked_gaussian_nll(
+            prediction=prediction,
+            target=target,
+            sigma=sigma,
+            inv_variance=inv_variance,
+        )
+
+
+def test_huber_data_loss_reduces_outlier_sensitivity_vs_quadratic():
+    prediction = jnp.array([[[10.0]]])
+    target = jnp.array([[[0.0]]])
+
+    huber_value = huber_data_loss(prediction, target, delta=1.0, normalize=False)
+    quadratic = 0.5 * (10.0**2)
+
+    assert huber_value < quadratic
+    assert jnp.allclose(huber_value, 9.5)
+
+
+def test_combine_loss_fns_weighted_sum_matches_manual():
+    prediction = jnp.array([[[3.0]]])
+    target = jnp.array([[[1.0]]])
+
+    l1 = lambda p, t: jnp.sum((p - t) ** 2)
+    l2 = lambda p, t: jnp.sum(jnp.abs(p - t))
+    combined = combine_loss_fns([l1, l2], weights=[0.5, 2.0])
+
+    expected = 0.5 * 4.0 + 2.0 * 2.0
+    assert jnp.allclose(combined(prediction, target), expected)
+
+
+def test_composed_loss_works_with_optimize_params():
+    pipeline = DummyPipeline()
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.0]), "metallicity": jnp.array([0.0])}}
+    target = jnp.array([[[5.0]]])
+
+    gaussian_term = lambda p, t: masked_gaussian_nll(
+        p,
+        t,
+        sigma=jnp.ones_like(t),
+        normalize=False,
+    )
+    robust_term = lambda p, t: huber_data_loss(p, t, delta=0.5, normalize=False)
+    loss_fn = combine_loss_fns([gaussian_term, robust_term], weights=[1.0, 0.1])
+
+    result = optimize_params(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        loss_fn=loss_fn,
+        learning_rate=0.1,
+        max_steps=120,
+        tol=1e-8,
+    )
+
+    assert result.loss_history[0] > result.loss_history[-1]
+    assert result.best_loss <= result.final_loss

--- a/tests/test_inference_objectives.py
+++ b/tests/test_inference_objectives.py
@@ -117,7 +117,9 @@ def test_optimize_ifu_cube_rejects_non_finite_weights():
     pipeline = CubeScalePipeline(jnp.ones((2, 2, 2)))
     static_data = _make_rubix_data()
     params_init = {"stars": {"age": jnp.array([0.2])}}
-    bad_weights = jnp.array([[[1.0, float("inf")], [1.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]])
+    bad_weights = jnp.array(
+        [[[1.0, float("inf")], [1.0, 1.0]], [[1.0, 1.0], [1.0, 1.0]]]
+    )
 
     with pytest.raises(ValueError, match="weights must be finite"):
         _ = optimize_ifu_cube(


### PR DESCRIPTION
## Summary
- add new rubix.inference.losses module with:
  - masked_gaussian_nll for uncertainty-aware IFU fitting
  - huber_data_loss for robust residual handling
  - combine_loss_fns for weighted composition of multiple data terms
- export loss helpers via rubix.inference
- add focused unit tests for math correctness, input validation, and optimizer integration
- document the new loss layer in inference docs/workflows

## Validation
- pre-commit run on changed files passed (black, isort, pydoclint)
- compileall passed for new module and tests
- pytest invocation in conda-run sandbox did not return output in this session (same known sandbox behavior), so this PR includes explicit unit coverage and hook-clean changes