### PR TITLE
feat(bench): add full-IFU variational inference benchmark harness

### DIFF
--- a/bench/benchmark_variational_inference.py
+++ b/bench/benchmark_variational_inference.py
@@ -44,21 +44,93 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Benchmark full-IFU variational inference runtime and diagnostics.",
     )
-    parser.add_argument("--nx", type=int, default=25)
-    parser.add_argument("--ny", type=int, default=25)
-    parser.add_argument("--nw", type=int, default=128)
-    parser.add_argument("--repeats", type=int, default=3)
-    parser.add_argument("--max-steps", type=int, default=200)
-    parser.add_argument("--num-samples", type=int, default=4)
-    parser.add_argument("--learning-rate", type=float, default=5e-2)
-    parser.add_argument("--beta-kl", type=float, default=1e-3)
-    parser.add_argument("--tol", type=float, default=1e-6)
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--use-mask", action="store_true")
-    parser.add_argument("--use-huber", action="store_true")
-    parser.add_argument("--huber-delta", type=float, default=0.2)
-    parser.add_argument("--huber-weight", type=float, default=0.1)
-    parser.add_argument("--no-warmup", action="store_true")
+    parser.add_argument(
+        "--nx",
+        type=int,
+        default=25,
+        help="Number of spatial pixels along the x axis.",
+    )
+    parser.add_argument(
+        "--ny",
+        type=int,
+        default=25,
+        help="Number of spatial pixels along the y axis.",
+    )
+    parser.add_argument(
+        "--nw",
+        type=int,
+        default=128,
+        help="Number of wavelength bins in the synthetic IFU cube.",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="Number of benchmark repetitions to run.",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=200,
+        help="Maximum number of optimization steps per run.",
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=4,
+        help="Number of variational samples used per optimization step.",
+    )
+    parser.add_argument(
+        "--learning-rate",
+        type=float,
+        default=5e-2,
+        help="Optimizer learning rate.",
+    )
+    parser.add_argument(
+        "--beta-kl",
+        type=float,
+        default=1e-3,
+        help="Weight applied to the KL-divergence term.",
+    )
+    parser.add_argument(
+        "--tol",
+        type=float,
+        default=1e-6,
+        help="Convergence tolerance for early stopping.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for reproducible benchmark runs.",
+    )
+    parser.add_argument(
+        "--use-mask",
+        action="store_true",
+        help="Apply a central spatial mask to the synthetic target cube.",
+    )
+    parser.add_argument(
+        "--use-huber",
+        action="store_true",
+        help="Use a Huber loss term instead of pure squared error.",
+    )
+    parser.add_argument(
+        "--huber-delta",
+        type=float,
+        default=0.2,
+        help="Delta threshold for the Huber loss.",
+    )
+    parser.add_argument(
+        "--huber-weight",
+        type=float,
+        default=0.1,
+        help="Weight assigned to the Huber loss term.",
+    )
+    parser.add_argument(
+        "--no-warmup",
+        action="store_true",
+        help="Disable any warmup run before timing benchmark repetitions.",
+    )
     return parser.parse_args()
 
 

--- a/bench/benchmark_variational_inference.py
+++ b/bench/benchmark_variational_inference.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+import argparse
+import json
+
+import jax.numpy as jnp
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference.vi_benchmark import (
+    benchmark_variational_inference,
+    vi_benchmark_result_to_dict,
+)
+
+
+class SyntheticScalePipeline:
+    """Simple synthetic pipeline for VI benchmark runs."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _make_static_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([0.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark full-IFU variational inference runtime and diagnostics.",
+    )
+    parser.add_argument("--nx", type=int, default=25)
+    parser.add_argument("--ny", type=int, default=25)
+    parser.add_argument("--nw", type=int, default=128)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--max-steps", type=int, default=200)
+    parser.add_argument("--num-samples", type=int, default=4)
+    parser.add_argument("--learning-rate", type=float, default=5e-2)
+    parser.add_argument("--beta-kl", type=float, default=1e-3)
+    parser.add_argument("--tol", type=float, default=1e-6)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--use-mask", action="store_true")
+    parser.add_argument("--use-huber", action="store_true")
+    parser.add_argument("--huber-delta", type=float, default=0.2)
+    parser.add_argument("--huber-weight", type=float, default=0.1)
+    parser.add_argument("--no-warmup", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    cube_shape = (args.nx, args.ny, args.nw)
+    template = jnp.ones(cube_shape, dtype=jnp.float32)
+    target = 1.7 * template
+
+    mask = None
+    if args.use_mask:
+        mask = jnp.zeros(cube_shape, dtype=jnp.float32)
+        x0 = args.nx // 4
+        x1 = 3 * args.nx // 4
+        y0 = args.ny // 4
+        y1 = 3 * args.ny // 4
+        mask = mask.at[x0:x1, y0:y1, :].set(1.0)
+
+    pipeline = SyntheticScalePipeline(template)
+    static_data = _make_static_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+
+    result = benchmark_variational_inference(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        sigma=jnp.ones_like(target),
+        mask=mask,
+        huber_delta=args.huber_delta if args.use_huber else None,
+        huber_weight=args.huber_weight if args.use_huber else 0.0,
+        learning_rate=args.learning_rate,
+        max_steps=args.max_steps,
+        tol=args.tol,
+        num_samples=args.num_samples,
+        beta_kl=args.beta_kl,
+        seed=args.seed,
+        repeats=args.repeats,
+        warmup=not args.no_warmup,
+    )
+
+    print(json.dumps(vi_benchmark_result_to_dict(result), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -170,6 +170,17 @@ The returned ``VariationalResult`` includes diagnostics such as
 ``best_step``, ``final_objective``, ``final_reconstruction``, ``final_kl``,
 and per-step ``grad_norm_history``/``update_norm_history``.
 
+To benchmark full-cube VI performance:
+
+.. code-block:: bash
+
+   python bench/benchmark_variational_inference.py \
+     --nx 25 --ny 25 --nw 256 \
+     --repeats 3 \
+     --max-steps 300 \
+     --num-samples 4 \
+     --use-mask --use-huber
+
 
 Performance Notes
 -----------------

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -181,6 +181,17 @@ To benchmark full-cube VI performance:
      --num-samples 4 \
      --use-mask --use-huber
 
+End-to-End Smoke Validation
+---------------------------
+
+Rubix includes a synthetic end-to-end smoke test that exercises deterministic
+optimization, stochastic optimization with explicit noise keys, and VI on a
+small IFU cube:
+
+.. code-block:: bash
+
+   pytest -q tests/test_inference_e2e_smoke.py
+
 
 Performance Notes
 -----------------

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -76,6 +76,14 @@ rubix.inference.variational module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.vi_benchmark module
+-----------------------------------
+
+.. automodule:: rubix.inference.vi_benchmark
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -30,6 +30,11 @@ from .variational import (
     optimize_variational_posterior,
     sample_diag_gaussian,
 )
+from .vi_benchmark import (
+    VIBenchmarkResult,
+    benchmark_variational_inference,
+    vi_benchmark_result_to_dict,
+)
 
 __all__ = [
     "IdentityTransform",
@@ -40,6 +45,7 @@ __all__ = [
     "IFUCubeBenchmarkResult",
     "OptimizationResult",
     "VariationalResult",
+    "VIBenchmarkResult",
     "apply_params",
     "apply_transforms",
     "build_age_metallicity_transforms",
@@ -62,6 +68,8 @@ __all__ = [
     "initialize_mean_field_params",
     "kl_diag_gaussian_to_standard_normal",
     "optimize_ifu_cube",
+    "benchmark_variational_inference",
+    "vi_benchmark_result_to_dict",
     "optimize_variational_ifu_cube",
     "optimize_variational_posterior",
     "optimize_params",

--- a/rubix/inference/vi_benchmark.py
+++ b/rubix/inference/vi_benchmark.py
@@ -145,8 +145,7 @@ def benchmark_variational_inference(
             optimizer=optimizer,
             seed=seed,
         )
-        _block_tree(last_result.posterior_mean_params)
-        _block_tree(last_result.posterior_log_std_params)
+        _block_tree(last_result)
         return last_result
 
     if warmup:

--- a/rubix/inference/vi_benchmark.py
+++ b/rubix/inference/vi_benchmark.py
@@ -1,0 +1,183 @@
+from dataclasses import asdict, dataclass
+from time import perf_counter
+from typing import Any, Mapping, Optional
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+
+from rubix.core.data import RubixData
+
+from .parameterization import TransformTree
+from .variational import VariationalResult, optimize_variational_ifu_cube
+
+ParamsTree = Mapping[str, Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class VIBenchmarkResult:
+    """Runtime and quality diagnostics for VI IFU-cube benchmarks."""
+
+    repeats: int
+    warmup: bool
+    runtimes_s: list[float]
+    mean_runtime_s: float
+    median_runtime_s: float
+    min_runtime_s: float
+    max_runtime_s: float
+    steps_run: int
+    final_objective: float
+    best_objective: float
+    final_reconstruction: float
+    final_kl: float
+    target_nbytes: int
+
+
+def estimate_array_nbytes(shape: tuple[int, ...], dtype: Any) -> int:
+    """Estimate memory footprint of a dense array in bytes."""
+    return int(np.prod(shape, dtype=np.int64) * np.dtype(dtype).itemsize)
+
+
+def _block_tree(tree: Any) -> None:
+    """Block on all JAX leaves in a pytree to ensure accurate timing."""
+    for leaf in jax.tree_util.tree_leaves(tree):
+        if hasattr(leaf, "block_until_ready"):
+            leaf.block_until_ready()
+
+
+def benchmark_variational_inference(
+    pipeline: Any,
+    params_init: ParamsTree,
+    static_data: RubixData,
+    target: jnp.ndarray,
+    sigma: Optional[jnp.ndarray] = None,
+    inv_variance: Optional[jnp.ndarray] = None,
+    mask: Optional[jnp.ndarray] = None,
+    normalize_loss: bool = True,
+    huber_delta: Optional[float] = None,
+    huber_weight: float = 0.0,
+    learning_rate: float = 5e-3,
+    max_steps: int = 500,
+    tol: float = 1e-6,
+    num_samples: int = 4,
+    beta_kl: float = 1e-3,
+    init_log_std: float = -2.0,
+    noise_key: Optional[jnp.ndarray] = None,
+    transforms: Optional[TransformTree] = None,
+    optimizer: Optional[optax.GradientTransformation] = None,
+    seed: int = 0,
+    repeats: int = 3,
+    warmup: bool = True,
+) -> VIBenchmarkResult:
+    """Benchmark full-IFU variational inference runtime and objective quality.
+
+    Args:
+        pipeline (Any): Pipeline-like object consumed by VI optimization.
+        params_init (ParamsTree): Initial constrained parameters.
+        static_data (RubixData): Static baseline data.
+        target (jnp.ndarray): Target IFU datacube.
+        sigma (Optional[jnp.ndarray], optional): Per-voxel uncertainty cube.
+            Defaults to ``None``.
+        inv_variance (Optional[jnp.ndarray], optional): Per-voxel inverse
+            variance cube. Defaults to ``None``.
+        mask (Optional[jnp.ndarray], optional): Optional binary voxel mask.
+            Defaults to ``None``.
+        normalize_loss (bool, optional): Whether to normalize data term.
+            Defaults to ``True``.
+        huber_delta (Optional[float], optional): Optional Huber transition.
+            Defaults to ``None``.
+        huber_weight (float, optional): Weight of robust Huber term.
+            Defaults to 0.0.
+        learning_rate (float, optional): Adam learning rate. Defaults to 5e-3.
+        max_steps (int, optional): Maximum VI steps. Defaults to 500.
+        tol (float, optional): Convergence threshold. Defaults to 1e-6.
+        num_samples (int, optional): Monte Carlo samples per VI step.
+            Defaults to 4.
+        beta_kl (float, optional): KL regularization weight. Defaults to 1e-3.
+        init_log_std (float, optional): Initial posterior log-std.
+            Defaults to -2.0.
+        noise_key (Optional[jnp.ndarray], optional): Optional stochastic key.
+            Defaults to ``None``.
+        transforms (Optional[TransformTree], optional): Optional parameter
+            transform tree. Defaults to ``None``.
+        optimizer (Optional[optax.GradientTransformation], optional): Optional
+            optimizer override. Defaults to ``None``.
+        seed (int, optional): Base random seed. Defaults to 0.
+        repeats (int, optional): Number of timed benchmark runs.
+            Defaults to 3.
+        warmup (bool, optional): Whether to run one untimed warmup.
+            Defaults to ``True``.
+
+    Raises:
+        ValueError: If ``repeats`` is smaller than one.
+        RuntimeError: If no VI result is produced.
+
+    Returns:
+        VIBenchmarkResult: Benchmark runtime summary and final VI diagnostics.
+    """
+    if repeats < 1:
+        raise ValueError("repeats must be >= 1")
+
+    last_result: Optional[VariationalResult] = None
+
+    def _run_once() -> VariationalResult:
+        nonlocal last_result
+        last_result = optimize_variational_ifu_cube(
+            pipeline=pipeline,
+            params_init=params_init,
+            static_data=static_data,
+            target=target,
+            sigma=sigma,
+            inv_variance=inv_variance,
+            mask=mask,
+            normalize_loss=normalize_loss,
+            huber_delta=huber_delta,
+            huber_weight=huber_weight,
+            learning_rate=learning_rate,
+            max_steps=max_steps,
+            tol=tol,
+            num_samples=num_samples,
+            beta_kl=beta_kl,
+            init_log_std=init_log_std,
+            noise_key=noise_key,
+            transforms=transforms,
+            optimizer=optimizer,
+            seed=seed,
+        )
+        _block_tree(last_result.posterior_mean_params)
+        _block_tree(last_result.posterior_log_std_params)
+        return last_result
+
+    if warmup:
+        _ = _run_once()
+
+    runtimes_s: list[float] = []
+    for _ in range(repeats):
+        start = perf_counter()
+        _ = _run_once()
+        runtimes_s.append(perf_counter() - start)
+
+    if last_result is None:  # pragma: no cover
+        raise RuntimeError("benchmark did not produce a variational result")
+
+    return VIBenchmarkResult(
+        repeats=repeats,
+        warmup=warmup,
+        runtimes_s=runtimes_s,
+        mean_runtime_s=float(np.mean(runtimes_s)),
+        median_runtime_s=float(np.median(runtimes_s)),
+        min_runtime_s=float(np.min(runtimes_s)),
+        max_runtime_s=float(np.max(runtimes_s)),
+        steps_run=last_result.steps_run,
+        final_objective=last_result.final_objective,
+        best_objective=last_result.best_objective,
+        final_reconstruction=last_result.final_reconstruction,
+        final_kl=last_result.final_kl,
+        target_nbytes=estimate_array_nbytes(target.shape, target.dtype),
+    )
+
+
+def vi_benchmark_result_to_dict(result: VIBenchmarkResult) -> dict[str, Any]:
+    """Convert VI benchmark dataclass to a JSON-serializable dictionary."""
+    return asdict(result)

--- a/rubix/inference/vi_benchmark.py
+++ b/rubix/inference/vi_benchmark.py
@@ -1,14 +1,13 @@
 from dataclasses import asdict, dataclass
-from time import perf_counter
 from typing import Any, Mapping, Optional
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
 
 from rubix.core.data import RubixData
 
+from .benchmark import _block_tree, benchmark_callable, estimate_array_nbytes
 from .parameterization import TransformTree
 from .variational import VariationalResult, optimize_variational_ifu_cube
 
@@ -32,18 +31,6 @@ class VIBenchmarkResult:
     final_reconstruction: float
     final_kl: float
     target_nbytes: int
-
-
-def estimate_array_nbytes(shape: tuple[int, ...], dtype: Any) -> int:
-    """Estimate memory footprint of a dense array in bytes."""
-    return int(np.prod(shape, dtype=np.int64) * np.dtype(dtype).itemsize)
-
-
-def _block_tree(tree: Any) -> None:
-    """Block on all JAX leaves in a pytree to ensure accurate timing."""
-    for leaf in jax.tree_util.tree_leaves(tree):
-        if hasattr(leaf, "block_until_ready"):
-            leaf.block_until_ready()
 
 
 def benchmark_variational_inference(
@@ -148,14 +135,7 @@ def benchmark_variational_inference(
         _block_tree(last_result)
         return last_result
 
-    if warmup:
-        _ = _run_once()
-
-    runtimes_s: list[float] = []
-    for _ in range(repeats):
-        start = perf_counter()
-        _ = _run_once()
-        runtimes_s.append(perf_counter() - start)
+    runtimes_s = benchmark_callable(_run_once, repeats=repeats, warmup=warmup)
 
     if last_result is None:  # pragma: no cover
         raise RuntimeError("benchmark did not produce a variational result")

--- a/tests/test_inference_e2e_smoke.py
+++ b/tests/test_inference_e2e_smoke.py
@@ -69,17 +69,17 @@ def test_e2e_deterministic_stochastic_and_vi_smoke():
     noise_key = jax.random.PRNGKey(7)
     pred_det = forward(pipeline, params_init, static_data, noise_key=None)
     pred_sto = forward(pipeline, params_init, static_data, noise_key=noise_key)
-    assert not jnp.allclose(pred_det, pred_sto), (
-        "noise_key had no effect on forward output; plumbing may be broken"
-    )
+    assert not jnp.allclose(
+        pred_det, pred_sto
+    ), "noise_key had no effect on forward output; plumbing may be broken"
 
     # Two distinct keys must also produce different noisy predictions.
     pred_sto2 = forward(
         pipeline, params_init, static_data, noise_key=jax.random.PRNGKey(42)
     )
-    assert not jnp.allclose(pred_sto, pred_sto2), (
-        "different noise_keys produced identical outputs; PRNG splitting may be broken"
-    )
+    assert not jnp.allclose(
+        pred_sto, pred_sto2
+    ), "different noise_keys produced identical outputs; PRNG splitting may be broken"
 
     # Stochastic run with explicit noise key should remain numerically stable.
     sto_result = optimize_params(

--- a/tests/test_inference_e2e_smoke.py
+++ b/tests/test_inference_e2e_smoke.py
@@ -95,7 +95,10 @@ def test_e2e_deterministic_stochastic_and_vi_smoke():
     assert jnp.isfinite(sto_result.final_loss)
     # The stochastic loss trace must also differ from the deterministic one at
     # step 0, confirming that noise_key was threaded through optimize_params.
-    assert sto_result.loss_history[0] != det_result.loss_history[0], (
+    assert not jnp.isclose(
+        jnp.array(sto_result.loss_history[0]),
+        jnp.array(det_result.loss_history[0]),
+    ), (
         "stochastic and deterministic first-step losses are identical; "
         "noise_key may not be reaching the pipeline inside optimize_params"
     )

--- a/tests/test_inference_e2e_smoke.py
+++ b/tests/test_inference_e2e_smoke.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 from rubix.core.data import Galaxy, GasData, RubixData, StarsData
-from rubix.inference import optimize_params, optimize_variational_ifu_cube
+from rubix.inference import forward, optimize_params, optimize_variational_ifu_cube
 
 
 class SyntheticIFUPipeline:
@@ -65,6 +65,22 @@ def test_e2e_deterministic_stochastic_and_vi_smoke():
     )
     assert det_result.loss_history[0] > det_result.loss_history[-1]
 
+    # Verify noise_key plumbing: predictions must differ between None and a key.
+    noise_key = jax.random.PRNGKey(7)
+    pred_det = forward(pipeline, params_init, static_data, noise_key=None)
+    pred_sto = forward(pipeline, params_init, static_data, noise_key=noise_key)
+    assert not jnp.allclose(pred_det, pred_sto), (
+        "noise_key had no effect on forward output; plumbing may be broken"
+    )
+
+    # Two distinct keys must also produce different noisy predictions.
+    pred_sto2 = forward(
+        pipeline, params_init, static_data, noise_key=jax.random.PRNGKey(42)
+    )
+    assert not jnp.allclose(pred_sto, pred_sto2), (
+        "different noise_keys produced identical outputs; PRNG splitting may be broken"
+    )
+
     # Stochastic run with explicit noise key should remain numerically stable.
     sto_result = optimize_params(
         pipeline=pipeline,
@@ -74,9 +90,15 @@ def test_e2e_deterministic_stochastic_and_vi_smoke():
         learning_rate=0.1,
         max_steps=20,
         tol=1e-8,
-        noise_key=jax.random.PRNGKey(7),
+        noise_key=noise_key,
     )
     assert jnp.isfinite(sto_result.final_loss)
+    # The stochastic loss trace must also differ from the deterministic one at
+    # step 0, confirming that noise_key was threaded through optimize_params.
+    assert sto_result.loss_history[0] != det_result.loss_history[0], (
+        "stochastic and deterministic first-step losses are identical; "
+        "noise_key may not be reaching the pipeline inside optimize_params"
+    )
 
     # VI smoke run on the same synthetic cube.
     vi_result = optimize_variational_ifu_cube(

--- a/tests/test_inference_e2e_smoke.py
+++ b/tests/test_inference_e2e_smoke.py
@@ -1,0 +1,96 @@
+import jax
+import jax.numpy as jnp
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import optimize_params, optimize_variational_ifu_cube
+
+
+class SyntheticIFUPipeline:
+    """Tiny synthetic pipeline supporting deterministic and stochastic runs."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        # Simple scale parameter from stars.age, plus optional keyed jitter
+        # to emulate stochastic forward passes.
+        scale = rubixdata.stars.age[0]
+        cube = scale * self.template
+
+        if rubixdata.noise_key is None:
+            return cube
+
+        noise = jax.random.normal(
+            rubixdata.noise_key, shape=cube.shape, dtype=cube.dtype
+        )
+        return cube + 0.01 * noise
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([0.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_e2e_deterministic_stochastic_and_vi_smoke():
+    cube_shape = (2, 2, 8)
+    template = jnp.ones(cube_shape, dtype=jnp.float32)
+    pipeline = SyntheticIFUPipeline(template)
+
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+    target = 1.5 * template
+
+    # Deterministic gradient-based fit
+    det_result = optimize_params(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=0.2,
+        max_steps=80,
+        tol=1e-8,
+    )
+    assert det_result.loss_history[0] > det_result.loss_history[-1]
+
+    # Stochastic run with explicit noise key should remain numerically stable.
+    sto_result = optimize_params(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=0.1,
+        max_steps=20,
+        tol=1e-8,
+        noise_key=jax.random.PRNGKey(7),
+    )
+    assert jnp.isfinite(sto_result.final_loss)
+
+    # VI smoke run on the same synthetic cube.
+    vi_result = optimize_variational_ifu_cube(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        sigma=jnp.ones_like(target),
+        learning_rate=5e-2,
+        max_steps=60,
+        tol=1e-8,
+        num_samples=3,
+        beta_kl=1e-4,
+        seed=3,
+    )
+    assert vi_result.objective_history[0] > vi_result.objective_history[-1]
+    assert jnp.isfinite(vi_result.final_objective)

--- a/tests/test_inference_vi_benchmark.py
+++ b/tests/test_inference_vi_benchmark.py
@@ -1,0 +1,82 @@
+import jax.numpy as jnp
+import pytest
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference.vi_benchmark import (
+    benchmark_variational_inference,
+    estimate_array_nbytes,
+)
+
+
+class CubeScalePipeline:
+    """Pipeline that scales a fixed cube template by stars.age[0]."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([0.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_estimate_array_nbytes_matches_expected():
+    assert estimate_array_nbytes((2, 3), jnp.float32) == 24
+
+
+def test_benchmark_variational_inference_rejects_invalid_repeats():
+    with pytest.raises(ValueError, match="repeats must be >= 1"):
+        benchmark_variational_inference(
+            pipeline=CubeScalePipeline(jnp.ones((1, 1, 1))),
+            params_init={"stars": {"age": jnp.array([0.2])}},
+            static_data=_make_rubix_data(),
+            target=jnp.ones((1, 1, 1)),
+            repeats=0,
+        )
+
+
+def test_benchmark_variational_inference_returns_summary():
+    cube_shape = (2, 2, 4)
+    template = jnp.ones(cube_shape, dtype=jnp.float32)
+    pipeline = CubeScalePipeline(template)
+    target = 1.5 * template
+    sigma = jnp.ones_like(target)
+
+    result = benchmark_variational_inference(
+        pipeline=pipeline,
+        params_init={"stars": {"age": jnp.array([0.2])}},
+        static_data=_make_rubix_data(),
+        target=target,
+        sigma=sigma,
+        learning_rate=5e-2,
+        max_steps=60,
+        tol=1e-8,
+        num_samples=3,
+        beta_kl=1e-4,
+        repeats=2,
+        warmup=False,
+        seed=5,
+    )
+
+    assert result.repeats == 2
+    assert len(result.runtimes_s) == 2
+    assert result.mean_runtime_s > 0.0
+    assert result.best_objective <= result.final_objective
+    assert result.target_nbytes == estimate_array_nbytes(cube_shape, target.dtype)


### PR DESCRIPTION
## Summary
- add rubix.inference.vi_benchmark with benchmark_variational_inference and VIBenchmarkResult
- add bench/benchmark_variational_inference.py CLI for synthetic full-IFU VI runtime studies
- add unit tests for benchmark behavior and diagnostics summary
- export benchmark APIs and document usage in inference workflow docs

## Validation
- pre-commit passed on changed files
- compileall passed for module, script, and tests