### PR TITLE
feat(inference): add config-driven objective factory for optimize/VI

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -304,6 +304,22 @@ For large particle counts, configure optional IFU accumulation controls:
 
 These settings are used by the particlewise IFU builders in ``rubix.core.ifu``.
 
+
+Synthetic Science Recipe
+------------------------
+
+Run an end-to-end synthetic workflow (optimize -> VI -> posterior predictive ->
+residual metrics) and persist science-ready outputs:
+
+.. code-block:: bash
+
+   python scripts/run_synthetic_science_recipe.py \
+     --output-dir outputs/science_recipe \
+     --nx 8 --ny 8 --nw 64 \
+     --optimize-steps 200 \
+     --vi-steps 200 \
+     --num-posterior-draws 16
+
 Benchmarking Full-IFU Optimization
 ----------------------------------
 

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -282,13 +282,13 @@ thresholds in benchmark runs.
 .. code-block:: python
 
    from rubix.inference import (
-       ObjectiveThresholds,
+       OptimizationObjectiveThresholds,
        RuntimeThresholds,
        check_ifu_optimization_guardrails,
    )
 
    runtime_limits = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-   objective_limits = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+   objective_limits = OptimizationObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
    check = check_ifu_optimization_guardrails(bench_result, runtime_limits, objective_limits)
    assert check.passed, check.message
 

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -212,6 +212,40 @@ small IFU cube:
 
    pytest -q tests/test_inference_e2e_smoke.py
 
+Checkpointing And Resume
+------------------------
+
+Both optimization and VI now support resumable state plus checkpoint helpers.
+
+.. code-block:: python
+
+   from rubix.inference import (
+       load_checkpoint,
+       make_optimization_checkpoint,
+       optimize_params,
+       resume_optimization_from_checkpoint,
+       save_checkpoint,
+   )
+
+   result, state = optimize_params(
+       pipeline=pipe_det,
+       params_init=params_init,
+       static_data=static_data,
+       target=target_cube,
+       max_steps=200,
+       return_state=True,
+   )
+   save_checkpoint(\"checkpoints/opt.pkl\", make_optimization_checkpoint(result, state))
+
+   ckpt = load_checkpoint(\"checkpoints/opt.pkl\")
+   resumed_result, resumed_state = resume_optimization_from_checkpoint(
+       ckpt,
+       pipeline=pipe_det,
+       static_data=static_data,
+       target=target_cube,
+       max_steps=200,
+   )
+
 
 Performance Notes
 -----------------

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -110,6 +110,26 @@ Rubix provides reusable loss builders for robust and probabilistic IFU fitting.
        weights=[1.0, 0.1],
    )
 
+You can also build these objectives directly from runtime config:
+
+.. code-block:: python
+
+   from rubix.inference import build_loss_from_user_config
+
+   cfg["inference"] = {
+       "objective": {
+           "kind": "combined",
+           "terms": [
+               {"kind": "gaussian_nll", "inv_variance_key": "ivar", "mask_key": "mask"},
+               {"kind": "huber", "delta": 0.2, "mask_key": "mask", "weight": 0.1},
+           ],
+       }
+   }
+   loss_fn = build_loss_from_user_config(
+       cfg,
+       tensors={"ivar": inverse_variance_cube, "mask": valid_voxel_mask},
+   )
+
 
 Finite-Difference Gradient Validation
 -------------------------------------

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -273,6 +273,26 @@ Generate posterior predictive cubes and science-ready residual summaries:
    metrics = summarize_masked_metrics(summary["mean"], target_cube, mask=valid_voxel_mask)
 
 
+Performance Guardrails
+----------------------
+
+Use guardrails to fail fast when runtime/objective regressions exceed expected
+thresholds in benchmark runs.
+
+.. code-block:: python
+
+   from rubix.inference import (
+       ObjectiveThresholds,
+       RuntimeThresholds,
+       check_ifu_optimization_guardrails,
+   )
+
+   runtime_limits = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+   objective_limits = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+   check = check_ifu_optimization_guardrails(bench_result, runtime_limits, objective_limits)
+   assert check.passed, check.message
+
+
 Performance Notes
 -----------------
 

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -235,9 +235,9 @@ Both optimization and VI now support resumable state plus checkpoint helpers.
        max_steps=200,
        return_state=True,
    )
-   save_checkpoint(\"checkpoints/opt.pkl\", make_optimization_checkpoint(result, state))
+   save_checkpoint("checkpoints/opt.pkl", make_optimization_checkpoint(result, state))
 
-   ckpt = load_checkpoint(\"checkpoints/opt.pkl\")
+   ckpt = load_checkpoint("checkpoints/opt.pkl")
    resumed_result, resumed_state = resume_optimization_from_checkpoint(
        ckpt,
        pipeline=pipe_det,

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -247,6 +247,32 @@ Both optimization and VI now support resumable state plus checkpoint helpers.
    )
 
 
+Posterior Predictive Outputs
+----------------------------
+
+Generate posterior predictive cubes and science-ready residual summaries:
+
+.. code-block:: python
+
+   from rubix.inference import (
+       compute_residual_products,
+       sample_posterior_predictive_cubes,
+       summarize_masked_metrics,
+       summarize_predictive_cube_samples,
+   )
+
+   samples = sample_posterior_predictive_cubes(
+       pipeline=pipe_det,
+       posterior_mean_params=vi.posterior_mean_params,
+       posterior_log_std_params=vi.posterior_log_std_params,
+       static_data=static_data,
+       num_samples=16,
+   )
+   summary = summarize_predictive_cube_samples(samples)
+   residual_maps = compute_residual_products(summary["mean"], target_cube)
+   metrics = summarize_masked_metrics(summary["mean"], target_cube, mask=valid_voxel_mask)
+
+
 Performance Notes
 -----------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -84,6 +84,14 @@ rubix.inference.parameterization module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.performance_guardrails module
+---------------------------------------------
+
+.. automodule:: rubix.inference.performance_guardrails
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.validation module
 ---------------------------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -116,6 +116,14 @@ rubix.inference.vi_benchmark module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.workflows module
+--------------------------------
+
+.. automodule:: rubix.inference.workflows
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -52,6 +52,14 @@ rubix.inference.optimize module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.posterior_predictive module
+-------------------------------------------
+
+.. automodule:: rubix.inference.posterior_predictive
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.objective_config module
 ---------------------------------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -12,6 +12,14 @@ rubix.inference.api module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.checkpoint module
+---------------------------------
+
+.. automodule:: rubix.inference.checkpoint
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.losses module
 -----------------------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -44,6 +44,14 @@ rubix.inference.optimize module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.objective_config module
+---------------------------------------
+
+.. automodule:: rubix.inference.objective_config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.objectives module
 ---------------------------------
 

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -63,6 +63,7 @@ from .vi_benchmark import (
     benchmark_variational_inference,
     vi_benchmark_result_to_dict,
 )
+from .workflows import run_synthetic_science_recipe, save_science_recipe_outputs
 
 __all__ = [
     "IdentityTransform",
@@ -122,4 +123,6 @@ __all__ = [
     "summarize_predictive_cube_samples",
     "save_checkpoint",
     "value_and_grad",
+    "run_synthetic_science_recipe",
+    "save_science_recipe_outputs",
 ]

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -36,9 +36,10 @@ from .parameterization import (
     inverse_transforms,
 )
 from .performance_guardrails import (
-    ObjectiveThresholds,
+    OptimizationObjectiveThresholds,
     PerformanceCheckResult,
     RuntimeThresholds,
+    VIObjectiveThresholds,
     check_ifu_optimization_guardrails,
     check_vi_guardrails,
 )
@@ -74,9 +75,10 @@ __all__ = [
     "IFUCubeBenchmarkResult",
     "OptimizationResult",
     "OptimizationState",
-    "ObjectiveThresholds",
+    "OptimizationObjectiveThresholds",
     "PerformanceCheckResult",
     "RuntimeThresholds",
+    "VIObjectiveThresholds",
     "VariationalResult",
     "VariationalState",
     "VIBenchmarkResult",

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -35,6 +35,12 @@ from .parameterization import (
     build_age_metallicity_transforms,
     inverse_transforms,
 )
+from .posterior_predictive import (
+    compute_residual_products,
+    sample_posterior_predictive_cubes,
+    summarize_masked_metrics,
+    summarize_predictive_cube_samples,
+)
 from .validation import GradientComparison, compare_gradients, finite_difference_grad
 from .variational import (
     VariationalResult,
@@ -77,6 +83,7 @@ __all__ = [
     "benchmark_ifu_cube_optimization",
     "benchmark_result_to_dict",
     "compare_gradients",
+    "compute_residual_products",
     "estimate_array_nbytes",
     "finite_difference_grad",
     "forward",
@@ -97,7 +104,10 @@ __all__ = [
     "optimize_params",
     "resume_optimization_from_checkpoint",
     "resume_variational_from_checkpoint",
+    "sample_posterior_predictive_cubes",
     "sample_diag_gaussian",
+    "summarize_masked_metrics",
+    "summarize_predictive_cube_samples",
     "save_checkpoint",
     "value_and_grad",
 ]

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -35,6 +35,13 @@ from .parameterization import (
     build_age_metallicity_transforms,
     inverse_transforms,
 )
+from .performance_guardrails import (
+    ObjectiveThresholds,
+    PerformanceCheckResult,
+    RuntimeThresholds,
+    check_ifu_optimization_guardrails,
+    check_vi_guardrails,
+)
 from .posterior_predictive import (
     compute_residual_products,
     sample_posterior_predictive_cubes,
@@ -66,6 +73,9 @@ __all__ = [
     "IFUCubeBenchmarkResult",
     "OptimizationResult",
     "OptimizationState",
+    "ObjectiveThresholds",
+    "PerformanceCheckResult",
+    "RuntimeThresholds",
     "VariationalResult",
     "VariationalState",
     "VIBenchmarkResult",
@@ -84,6 +94,8 @@ __all__ = [
     "benchmark_result_to_dict",
     "compare_gradients",
     "compute_residual_products",
+    "check_ifu_optimization_guardrails",
+    "check_vi_guardrails",
     "estimate_array_nbytes",
     "finite_difference_grad",
     "forward",

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -8,11 +8,24 @@ from .benchmark import (
     benchmark_result_to_dict,
     estimate_array_nbytes,
 )
+from .checkpoint import (
+    load_checkpoint,
+    make_optimization_checkpoint,
+    make_variational_checkpoint,
+    resume_optimization_from_checkpoint,
+    resume_variational_from_checkpoint,
+    save_checkpoint,
+)
 from .losses import combine_loss_fns, huber_data_loss, masked_gaussian_nll
 from .modes import get_pipeline_name_for_mode, make_inference_pipeline
 from .objective_config import build_loss_from_config, build_loss_from_user_config
 from .objectives import build_ifu_cube_loss, masked_weighted_mse
-from .optimize import OptimizationResult, optimize_ifu_cube, optimize_params
+from .optimize import (
+    OptimizationResult,
+    OptimizationState,
+    optimize_ifu_cube,
+    optimize_params,
+)
 from .parameterization import (
     IdentityTransform,
     ParameterTransform,
@@ -25,6 +38,7 @@ from .parameterization import (
 from .validation import GradientComparison, compare_gradients, finite_difference_grad
 from .variational import (
     VariationalResult,
+    VariationalState,
     initialize_mean_field_params,
     kl_diag_gaussian_to_standard_normal,
     optimize_variational_ifu_cube,
@@ -45,10 +59,15 @@ __all__ = [
     "GradientComparison",
     "IFUCubeBenchmarkResult",
     "OptimizationResult",
+    "OptimizationState",
     "VariationalResult",
+    "VariationalState",
     "VIBenchmarkResult",
     "apply_params",
     "apply_transforms",
+    "load_checkpoint",
+    "make_optimization_checkpoint",
+    "make_variational_checkpoint",
     "build_age_metallicity_transforms",
     "build_ifu_cube_loss",
     "build_loss_from_config",
@@ -76,6 +95,9 @@ __all__ = [
     "optimize_variational_ifu_cube",
     "optimize_variational_posterior",
     "optimize_params",
+    "resume_optimization_from_checkpoint",
+    "resume_variational_from_checkpoint",
     "sample_diag_gaussian",
+    "save_checkpoint",
     "value_and_grad",
 ]

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -10,6 +10,7 @@ from .benchmark import (
 )
 from .losses import combine_loss_fns, huber_data_loss, masked_gaussian_nll
 from .modes import get_pipeline_name_for_mode, make_inference_pipeline
+from .objective_config import build_loss_from_config, build_loss_from_user_config
 from .objectives import build_ifu_cube_loss, masked_weighted_mse
 from .optimize import OptimizationResult, optimize_ifu_cube, optimize_params
 from .parameterization import (
@@ -50,6 +51,8 @@ __all__ = [
     "apply_transforms",
     "build_age_metallicity_transforms",
     "build_ifu_cube_loss",
+    "build_loss_from_config",
+    "build_loss_from_user_config",
     "combine_loss_fns",
     "benchmark_callable",
     "benchmark_ifu_cube_optimization",

--- a/rubix/inference/checkpoint.py
+++ b/rubix/inference/checkpoint.py
@@ -20,6 +20,15 @@ from .variational import (
 CheckpointPath = Union[str, Path]
 
 
+def _resolve_config_value(
+    override: Any, stored_config: dict[str, Any], key: str, default: Any
+) -> Any:
+    """Return *override* if not ``None``, else the stored config value, else *default*."""
+    if override is not None:
+        return override
+    return stored_config.get(key, default)
+
+
 def save_checkpoint(path: CheckpointPath, payload: Mapping[str, Any]) -> None:
     """Save a checkpoint payload to disk via pickle.
 
@@ -227,14 +236,12 @@ def resume_optimization_from_checkpoint(
         raise ValueError("optimization checkpoint is missing valid result/state")
 
     stored_config: dict[str, Any] = checkpoint.get("config") or {}
-    resolved_learning_rate: float = (
-        learning_rate if learning_rate is not None else stored_config.get("learning_rate", 1e-3)
+    resolved_learning_rate: float = _resolve_config_value(
+        learning_rate, stored_config, "learning_rate", 1e-3
     )
-    resolved_tol: float = (
-        tol if tol is not None else stored_config.get("tol", 1e-6)
-    )
-    resolved_transforms: Optional[TransformTree] = (
-        transforms if transforms is not None else stored_config.get("transforms")
+    resolved_tol: float = _resolve_config_value(tol, stored_config, "tol", 1e-6)
+    resolved_transforms: Optional[TransformTree] = _resolve_config_value(
+        transforms, stored_config, "transforms", None
     )
 
     resumed = optimize_params(
@@ -338,26 +345,22 @@ def resume_variational_from_checkpoint(
         raise ValueError("variational checkpoint is missing valid result/state")
 
     stored_config: dict[str, Any] = checkpoint.get("config") or {}
-    resolved_learning_rate: float = (
-        learning_rate if learning_rate is not None else stored_config.get("learning_rate", 5e-3)
+    resolved_learning_rate: float = _resolve_config_value(
+        learning_rate, stored_config, "learning_rate", 5e-3
     )
-    resolved_tol: float = (
-        tol if tol is not None else stored_config.get("tol", 1e-6)
+    resolved_tol: float = _resolve_config_value(tol, stored_config, "tol", 1e-6)
+    resolved_num_samples: int = _resolve_config_value(
+        num_samples, stored_config, "num_samples", 4
     )
-    resolved_num_samples: int = (
-        num_samples if num_samples is not None else stored_config.get("num_samples", 4)
+    resolved_beta_kl: float = _resolve_config_value(
+        beta_kl, stored_config, "beta_kl", 1e-3
     )
-    resolved_beta_kl: float = (
-        beta_kl if beta_kl is not None else stored_config.get("beta_kl", 1e-3)
+    resolved_init_log_std: float = _resolve_config_value(
+        init_log_std, stored_config, "init_log_std", -2.0
     )
-    resolved_init_log_std: float = (
-        init_log_std if init_log_std is not None else stored_config.get("init_log_std", -2.0)
-    )
-    resolved_seed: int = (
-        seed if seed is not None else stored_config.get("seed", 0)
-    )
-    resolved_transforms: Optional[TransformTree] = (
-        transforms if transforms is not None else stored_config.get("transforms")
+    resolved_seed: int = _resolve_config_value(seed, stored_config, "seed", 0)
+    resolved_transforms: Optional[TransformTree] = _resolve_config_value(
+        transforms, stored_config, "transforms", None
     )
 
     resumed = optimize_variational_posterior(

--- a/rubix/inference/checkpoint.py
+++ b/rubix/inference/checkpoint.py
@@ -1,0 +1,172 @@
+import pickle
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import jax.numpy as jnp
+import optax
+from beartype.typing import Union
+
+from rubix.core.data import RubixData
+
+from .api import LossFn
+from .optimize import OptimizationResult, OptimizationState, optimize_params
+from .parameterization import TransformTree
+from .variational import (
+    VariationalResult,
+    VariationalState,
+    optimize_variational_posterior,
+)
+
+CheckpointPath = Union[str, Path]
+
+
+def save_checkpoint(path: CheckpointPath, payload: Mapping[str, Any]) -> None:
+    """Save a checkpoint payload to disk via pickle.
+
+    Args:
+        path (CheckpointPath): Destination checkpoint path.
+        payload (Mapping[str, Any]): Serializable checkpoint mapping.
+    """
+    checkpoint_path = Path(path)
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    with checkpoint_path.open("wb") as f:
+        pickle.dump(dict(payload), f)
+
+
+def load_checkpoint(path: CheckpointPath) -> dict[str, Any]:
+    """Load a checkpoint payload from disk.
+
+    Args:
+        path (CheckpointPath): Checkpoint path.
+
+    Raises:
+        ValueError: If the loaded payload is not a dictionary.
+
+    Returns:
+        dict[str, Any]: Loaded checkpoint mapping.
+    """
+    with Path(path).open("rb") as f:
+        payload = pickle.load(f)
+    if not isinstance(payload, dict):
+        raise ValueError("checkpoint payload must be a dictionary")
+    return payload
+
+
+def make_optimization_checkpoint(
+    result: OptimizationResult,
+    state: OptimizationState,
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build a checkpoint payload for optimization resume."""
+    return {
+        "kind": "optimization",
+        "result": result,
+        "state": state,
+        "metadata": dict(metadata or {}),
+    }
+
+
+def make_variational_checkpoint(
+    result: VariationalResult,
+    state: VariationalState,
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build a checkpoint payload for variational resume."""
+    return {
+        "kind": "variational",
+        "result": result,
+        "state": state,
+        "metadata": dict(metadata or {}),
+    }
+
+
+def resume_optimization_from_checkpoint(
+    checkpoint: Mapping[str, Any],
+    pipeline: Any,
+    static_data: RubixData,
+    target: jnp.ndarray,
+    learning_rate: float = 1e-3,
+    max_steps: int = 500,
+    tol: float = 1e-6,
+    loss_fn: Optional[LossFn] = None,
+    noise_key: Optional[jnp.ndarray] = None,
+    transforms: Optional[TransformTree] = None,
+    optimizer: Optional[optax.GradientTransformation] = None,
+) -> tuple[OptimizationResult, OptimizationState]:
+    """Resume gradient optimization from an optimization checkpoint."""
+    if checkpoint.get("kind") != "optimization":
+        raise ValueError("checkpoint kind must be 'optimization'")
+
+    result = checkpoint.get("result")
+    state = checkpoint.get("state")
+    if not isinstance(result, OptimizationResult) or not isinstance(
+        state, OptimizationState
+    ):
+        raise ValueError("optimization checkpoint is missing valid result/state")
+
+    resumed = optimize_params(
+        pipeline=pipeline,
+        params_init=result.params,
+        static_data=static_data,
+        target=target,
+        learning_rate=learning_rate,
+        max_steps=max_steps,
+        tol=tol,
+        loss_fn=loss_fn,
+        noise_key=noise_key,
+        transforms=transforms,
+        optimizer=optimizer,
+        state_init=state,
+        return_state=True,
+    )
+    return resumed
+
+
+def resume_variational_from_checkpoint(
+    checkpoint: Mapping[str, Any],
+    pipeline: Any,
+    static_data: RubixData,
+    target: jnp.ndarray,
+    learning_rate: float = 5e-3,
+    max_steps: int = 500,
+    tol: float = 1e-6,
+    num_samples: int = 4,
+    beta_kl: float = 1e-3,
+    init_log_std: float = -2.0,
+    loss_fn: Optional[LossFn] = None,
+    noise_key: Optional[jnp.ndarray] = None,
+    transforms: Optional[TransformTree] = None,
+    optimizer: Optional[optax.GradientTransformation] = None,
+    seed: int = 0,
+) -> tuple[VariationalResult, VariationalState]:
+    """Resume variational inference from a variational checkpoint."""
+    if checkpoint.get("kind") != "variational":
+        raise ValueError("checkpoint kind must be 'variational'")
+
+    result = checkpoint.get("result")
+    state = checkpoint.get("state")
+    if not isinstance(result, VariationalResult) or not isinstance(
+        state, VariationalState
+    ):
+        raise ValueError("variational checkpoint is missing valid result/state")
+
+    resumed = optimize_variational_posterior(
+        pipeline=pipeline,
+        params_init=result.posterior_mean_constrained_params,
+        static_data=static_data,
+        target=target,
+        learning_rate=learning_rate,
+        max_steps=max_steps,
+        tol=tol,
+        num_samples=num_samples,
+        beta_kl=beta_kl,
+        init_log_std=init_log_std,
+        loss_fn=loss_fn,
+        noise_key=noise_key,
+        transforms=transforms,
+        optimizer=optimizer,
+        seed=seed,
+        state_init=state,
+        return_state=True,
+    )
+    return resumed

--- a/rubix/inference/checkpoint.py
+++ b/rubix/inference/checkpoint.py
@@ -30,7 +30,7 @@ def save_checkpoint(path: CheckpointPath, payload: Mapping[str, Any]) -> None:
     checkpoint_path = Path(path)
     checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
     with checkpoint_path.open("wb") as f:
-        pickle.dump(dict(payload), f)
+        pickle.dump(dict(payload), f, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 def load_checkpoint(path: CheckpointPath) -> dict[str, Any]:

--- a/rubix/inference/checkpoint.py
+++ b/rubix/inference/checkpoint.py
@@ -36,6 +36,11 @@ def save_checkpoint(path: CheckpointPath, payload: Mapping[str, Any]) -> None:
 def load_checkpoint(path: CheckpointPath) -> dict[str, Any]:
     """Load a checkpoint payload from disk.
 
+    .. warning::
+        This function uses :mod:`pickle`, which can execute arbitrary code when
+        loading data from untrusted files.  Only load checkpoints from sources
+        you trust.
+
     Args:
         path (CheckpointPath): Checkpoint path.
 
@@ -55,13 +60,45 @@ def load_checkpoint(path: CheckpointPath) -> dict[str, Any]:
 def make_optimization_checkpoint(
     result: OptimizationResult,
     state: OptimizationState,
+    transforms: Optional[TransformTree] = None,
+    learning_rate: float = 1e-3,
+    tol: float = 1e-6,
     metadata: Optional[Mapping[str, Any]] = None,
 ) -> dict[str, Any]:
-    """Build a checkpoint payload for optimization resume."""
+    """Build a checkpoint payload for optimization resume.
+
+    The supplied configuration (``transforms``, ``learning_rate``, ``tol``) is
+    stored in the checkpoint so that :func:`resume_optimization_from_checkpoint`
+    can fall back to these values when they are not re-supplied by the caller,
+    making resumes reproducible without requiring the caller to re-specify every
+    hyperparameter.
+
+    Args:
+        result (OptimizationResult): Result from the completed optimization run.
+        state (OptimizationState): Internal state from the completed run.
+        transforms (Optional[TransformTree], optional): Transform tree used
+            during the run.  Stored so that :func:`resume_optimization_from_checkpoint`
+            can default to it on resume.  Defaults to ``None``.
+        learning_rate (float, optional): Learning rate used during the run.
+            Defaults to 1e-3.
+        tol (float, optional): Convergence tolerance used during the run.
+            Defaults to 1e-6.
+        metadata (Optional[Mapping[str, Any]], optional): Arbitrary extra
+            metadata to embed in the checkpoint.  Defaults to ``None``.
+
+    Returns:
+        dict[str, Any]: Serializable checkpoint mapping.
+    """
+    config = {
+        "transforms": transforms,
+        "learning_rate": learning_rate,
+        "tol": tol,
+    }
     return {
         "kind": "optimization",
         "result": result,
         "state": state,
+        "config": config,
         "metadata": dict(metadata or {}),
     }
 
@@ -69,13 +106,58 @@ def make_optimization_checkpoint(
 def make_variational_checkpoint(
     result: VariationalResult,
     state: VariationalState,
+    transforms: Optional[TransformTree] = None,
+    learning_rate: float = 5e-3,
+    tol: float = 1e-6,
+    num_samples: int = 4,
+    beta_kl: float = 1e-3,
+    init_log_std: float = -2.0,
+    seed: int = 0,
     metadata: Optional[Mapping[str, Any]] = None,
 ) -> dict[str, Any]:
-    """Build a checkpoint payload for variational resume."""
+    """Build a checkpoint payload for variational inference resume.
+
+    The supplied configuration is stored so that
+    :func:`resume_variational_from_checkpoint` can fall back to these values
+    when they are not re-supplied by the caller.
+
+    Args:
+        result (VariationalResult): Result from the completed VI run.
+        state (VariationalState): Internal state from the completed run.
+        transforms (Optional[TransformTree], optional): Transform tree used
+            during the run.  Defaults to ``None``.
+        learning_rate (float, optional): Learning rate used during the run.
+            Defaults to 5e-3.
+        tol (float, optional): Convergence tolerance used during the run.
+            Defaults to 1e-6.
+        num_samples (int, optional): MC samples per step used during the run.
+            Defaults to 4.
+        beta_kl (float, optional): KL weight used during the run.
+            Defaults to 1e-3.
+        init_log_std (float, optional): Initial posterior log-std used at the
+            start of the run.  Defaults to -2.0.
+        seed (int, optional): Random seed used at the start of the run.
+            Defaults to 0.
+        metadata (Optional[Mapping[str, Any]], optional): Arbitrary extra
+            metadata.  Defaults to ``None``.
+
+    Returns:
+        dict[str, Any]: Serializable checkpoint mapping.
+    """
+    config = {
+        "transforms": transforms,
+        "learning_rate": learning_rate,
+        "tol": tol,
+        "num_samples": num_samples,
+        "beta_kl": beta_kl,
+        "init_log_std": init_log_std,
+        "seed": seed,
+    }
     return {
         "kind": "variational",
         "result": result,
         "state": state,
+        "config": config,
         "metadata": dict(metadata or {}),
     }
 

--- a/rubix/inference/checkpoint.py
+++ b/rubix/inference/checkpoint.py
@@ -167,15 +167,55 @@ def resume_optimization_from_checkpoint(
     pipeline: Any,
     static_data: RubixData,
     target: jnp.ndarray,
-    learning_rate: float = 1e-3,
+    learning_rate: Optional[float] = None,
     max_steps: int = 500,
-    tol: float = 1e-6,
+    tol: Optional[float] = None,
     loss_fn: Optional[LossFn] = None,
     noise_key: Optional[jnp.ndarray] = None,
     transforms: Optional[TransformTree] = None,
     optimizer: Optional[optax.GradientTransformation] = None,
 ) -> tuple[OptimizationResult, OptimizationState]:
-    """Resume gradient optimization from an optimization checkpoint."""
+    """Resume gradient optimization from an optimization checkpoint.
+
+    Hyperparameters (``learning_rate``, ``tol``, ``transforms``) that are not
+    explicitly provided default to the values stored in the checkpoint by
+    :func:`make_optimization_checkpoint`, so the resumed run uses the same
+    configuration as the original without requiring the caller to re-specify
+    every hyperparameter.
+
+    Args:
+        checkpoint (Mapping[str, Any]): Checkpoint payload returned by
+            :func:`load_checkpoint`.
+        pipeline (Any): Pipeline-like object consumed by
+            :func:`rubix.inference.loss`.
+        static_data (RubixData): Baseline RubixData passed to the forward
+            model.
+        target (jnp.ndarray): Target datacube or statistic.
+        learning_rate (Optional[float], optional): Override for the learning
+            rate.  Defaults to ``None`` (use value stored in the checkpoint).
+        max_steps (int, optional): Maximum additional optimization steps.
+            Defaults to 500.
+        tol (Optional[float], optional): Override for the convergence
+            tolerance.  Defaults to ``None`` (use value stored in the
+            checkpoint).
+        loss_fn (Optional[LossFn], optional): Optional custom loss function.
+            Defaults to ``None`` (sum-of-squares).
+        noise_key (Optional[jnp.ndarray], optional): Optional key for
+            stochastic pipelines.  Defaults to ``None``.
+        transforms (Optional[TransformTree], optional): Override for the
+            transform tree.  Defaults to ``None`` (use value stored in the
+            checkpoint).
+        optimizer (Optional[optax.GradientTransformation], optional): Custom
+            Optax optimizer.  Defaults to ``None`` (Adam).
+
+    Raises:
+        ValueError: If the checkpoint kind is not ``'optimization'`` or the
+            checkpoint is missing valid result/state fields.
+
+    Returns:
+        tuple[OptimizationResult, OptimizationState]: Resumed result and
+            updated internal state.
+    """
     if checkpoint.get("kind") != "optimization":
         raise ValueError("checkpoint kind must be 'optimization'")
 
@@ -186,17 +226,28 @@ def resume_optimization_from_checkpoint(
     ):
         raise ValueError("optimization checkpoint is missing valid result/state")
 
+    stored_config: dict[str, Any] = checkpoint.get("config") or {}
+    resolved_learning_rate: float = (
+        learning_rate if learning_rate is not None else stored_config.get("learning_rate", 1e-3)
+    )
+    resolved_tol: float = (
+        tol if tol is not None else stored_config.get("tol", 1e-6)
+    )
+    resolved_transforms: Optional[TransformTree] = (
+        transforms if transforms is not None else stored_config.get("transforms")
+    )
+
     resumed = optimize_params(
         pipeline=pipeline,
         params_init=result.params,
         static_data=static_data,
         target=target,
-        learning_rate=learning_rate,
+        learning_rate=resolved_learning_rate,
         max_steps=max_steps,
-        tol=tol,
+        tol=resolved_tol,
         loss_fn=loss_fn,
         noise_key=noise_key,
-        transforms=transforms,
+        transforms=resolved_transforms,
         optimizer=optimizer,
         state_init=state,
         return_state=True,
@@ -209,19 +260,73 @@ def resume_variational_from_checkpoint(
     pipeline: Any,
     static_data: RubixData,
     target: jnp.ndarray,
-    learning_rate: float = 5e-3,
+    learning_rate: Optional[float] = None,
     max_steps: int = 500,
-    tol: float = 1e-6,
-    num_samples: int = 4,
-    beta_kl: float = 1e-3,
-    init_log_std: float = -2.0,
+    tol: Optional[float] = None,
+    num_samples: Optional[int] = None,
+    beta_kl: Optional[float] = None,
+    init_log_std: Optional[float] = None,
     loss_fn: Optional[LossFn] = None,
     noise_key: Optional[jnp.ndarray] = None,
     transforms: Optional[TransformTree] = None,
     optimizer: Optional[optax.GradientTransformation] = None,
-    seed: int = 0,
+    seed: Optional[int] = None,
 ) -> tuple[VariationalResult, VariationalState]:
-    """Resume variational inference from a variational checkpoint."""
+    """Resume variational inference from a variational checkpoint.
+
+    Hyperparameters (``learning_rate``, ``tol``, ``num_samples``, ``beta_kl``,
+    ``init_log_std``, ``seed``, ``transforms``) that are not explicitly
+    provided default to the values stored in the checkpoint by
+    :func:`make_variational_checkpoint`, so the resumed run uses the same
+    configuration as the original without requiring the caller to re-specify
+    every hyperparameter.
+
+    Args:
+        checkpoint (Mapping[str, Any]): Checkpoint payload returned by
+            :func:`load_checkpoint`.
+        pipeline (Any): Pipeline-like object consumed by
+            :func:`rubix.inference.loss`.
+        static_data (RubixData): Baseline RubixData passed to the forward
+            model.
+        target (jnp.ndarray): Target datacube or statistic.
+        learning_rate (Optional[float], optional): Override for the learning
+            rate.  Defaults to ``None`` (use value stored in the checkpoint).
+        max_steps (int, optional): Maximum additional VI steps.
+            Defaults to 500.
+        tol (Optional[float], optional): Override for the convergence
+            tolerance.  Defaults to ``None`` (use value stored in the
+            checkpoint).
+        num_samples (Optional[int], optional): Override for the number of MC
+            samples per step.  Defaults to ``None`` (use checkpoint value).
+        beta_kl (Optional[float], optional): Override for the KL weight.
+            Defaults to ``None`` (use checkpoint value).
+        init_log_std (Optional[float], optional): Override for the initial
+            posterior log-std.  Defaults to ``None`` (use checkpoint value).
+            This value is ignored when ``state_init`` is passed to the
+            underlying VI function (i.e. always during resume), but is kept
+            for API symmetry.
+        loss_fn (Optional[LossFn], optional): Optional custom reconstruction
+            loss.  Defaults to ``None`` (sum-of-squares).
+        noise_key (Optional[jnp.ndarray], optional): Optional key for
+            stochastic pipelines.  Defaults to ``None``.
+        transforms (Optional[TransformTree], optional): Override for the
+            transform tree.  Defaults to ``None`` (use checkpoint value).
+        optimizer (Optional[optax.GradientTransformation], optional): Custom
+            Optax optimizer.  Defaults to ``None`` (Adam).
+        seed (Optional[int], optional): Override for the random seed.
+            Defaults to ``None`` (use checkpoint value).  This value is
+            ignored when ``state_init`` is passed to the underlying VI
+            function (i.e. always during resume), but is kept for API
+            symmetry.
+
+    Raises:
+        ValueError: If the checkpoint kind is not ``'variational'`` or the
+            checkpoint is missing valid result/state fields.
+
+    Returns:
+        tuple[VariationalResult, VariationalState]: Resumed result and
+            updated internal state.
+    """
     if checkpoint.get("kind") != "variational":
         raise ValueError("checkpoint kind must be 'variational'")
 
@@ -232,22 +337,45 @@ def resume_variational_from_checkpoint(
     ):
         raise ValueError("variational checkpoint is missing valid result/state")
 
+    stored_config: dict[str, Any] = checkpoint.get("config") or {}
+    resolved_learning_rate: float = (
+        learning_rate if learning_rate is not None else stored_config.get("learning_rate", 5e-3)
+    )
+    resolved_tol: float = (
+        tol if tol is not None else stored_config.get("tol", 1e-6)
+    )
+    resolved_num_samples: int = (
+        num_samples if num_samples is not None else stored_config.get("num_samples", 4)
+    )
+    resolved_beta_kl: float = (
+        beta_kl if beta_kl is not None else stored_config.get("beta_kl", 1e-3)
+    )
+    resolved_init_log_std: float = (
+        init_log_std if init_log_std is not None else stored_config.get("init_log_std", -2.0)
+    )
+    resolved_seed: int = (
+        seed if seed is not None else stored_config.get("seed", 0)
+    )
+    resolved_transforms: Optional[TransformTree] = (
+        transforms if transforms is not None else stored_config.get("transforms")
+    )
+
     resumed = optimize_variational_posterior(
         pipeline=pipeline,
         params_init=result.posterior_mean_constrained_params,
         static_data=static_data,
         target=target,
-        learning_rate=learning_rate,
+        learning_rate=resolved_learning_rate,
         max_steps=max_steps,
-        tol=tol,
-        num_samples=num_samples,
-        beta_kl=beta_kl,
-        init_log_std=init_log_std,
+        tol=resolved_tol,
+        num_samples=resolved_num_samples,
+        beta_kl=resolved_beta_kl,
+        init_log_std=resolved_init_log_std,
         loss_fn=loss_fn,
         noise_key=noise_key,
-        transforms=transforms,
+        transforms=resolved_transforms,
         optimizer=optimizer,
-        seed=seed,
+        seed=resolved_seed,
         state_init=state,
         return_state=True,
     )

--- a/rubix/inference/objective_config.py
+++ b/rubix/inference/objective_config.py
@@ -1,0 +1,169 @@
+from collections.abc import Mapping
+from typing import Any, Optional
+
+import jax.numpy as jnp
+
+from .api import LossFn
+from .losses import combine_loss_fns, huber_data_loss, masked_gaussian_nll
+from .objectives import build_ifu_cube_loss
+
+TensorMap = Mapping[str, jnp.ndarray]
+
+
+def _get_tensor(
+    tensors: Optional[TensorMap],
+    key: Optional[str],
+    field_name: str,
+) -> Optional[jnp.ndarray]:
+    """Resolve optional tensor by key from a tensor map."""
+    if key is None:
+        return None
+
+    if tensors is None:
+        raise ValueError(f"{field_name} key provided but tensors mapping is None")
+
+    if key not in tensors:
+        raise ValueError(f"{field_name} key '{key}' not found in tensors mapping")
+
+    return tensors[key]
+
+
+def _build_single_loss_from_config(
+    term_cfg: Mapping[str, Any],
+    tensors: Optional[TensorMap],
+) -> LossFn:
+    """Build a single prediction-target loss from config."""
+    kind = term_cfg.get("kind", "mse")
+
+    if kind == "mse":
+        mask = _get_tensor(tensors, term_cfg.get("mask_key"), "mask")
+        weights = _get_tensor(tensors, term_cfg.get("weights_key"), "weights")
+        normalize = bool(term_cfg.get("normalize", True))
+        eps = float(term_cfg.get("eps", 1e-12))
+        return build_ifu_cube_loss(
+            mask=mask,
+            weights=weights,
+            normalize=normalize,
+            eps=eps,
+        )
+
+    if kind == "gaussian_nll":
+        sigma = _get_tensor(tensors, term_cfg.get("sigma_key"), "sigma")
+        inv_variance = _get_tensor(
+            tensors, term_cfg.get("inv_variance_key"), "inv_variance"
+        )
+        mask = _get_tensor(tensors, term_cfg.get("mask_key"), "mask")
+        normalize = bool(term_cfg.get("normalize", True))
+        eps = float(term_cfg.get("eps", 1e-12))
+
+        def _loss_fn(prediction: jnp.ndarray, target: jnp.ndarray) -> jnp.ndarray:
+            return masked_gaussian_nll(
+                prediction=prediction,
+                target=target,
+                sigma=sigma,
+                inv_variance=inv_variance,
+                mask=mask,
+                normalize=normalize,
+                eps=eps,
+            )
+
+        return _loss_fn
+
+    if kind == "huber":
+        delta = float(term_cfg.get("delta", 1.0))
+        mask = _get_tensor(tensors, term_cfg.get("mask_key"), "mask")
+        weights = _get_tensor(tensors, term_cfg.get("weights_key"), "weights")
+        normalize = bool(term_cfg.get("normalize", True))
+        eps = float(term_cfg.get("eps", 1e-12))
+
+        def _loss_fn(prediction: jnp.ndarray, target: jnp.ndarray) -> jnp.ndarray:
+            return huber_data_loss(
+                prediction=prediction,
+                target=target,
+                delta=delta,
+                mask=mask,
+                weights=weights,
+                normalize=normalize,
+                eps=eps,
+            )
+
+        return _loss_fn
+
+    raise ValueError(
+        "Unsupported objective kind "
+        f"'{kind}'. Supported kinds: {'mse', 'gaussian_nll', 'huber'}"
+    )
+
+
+def build_loss_from_config(
+    objective_config: Mapping[str, Any],
+    tensors: Optional[TensorMap] = None,
+) -> LossFn:
+    """Build a composable loss function from objective configuration.
+
+    The schema supports a single term or a weighted combination:
+
+    - Single term:
+      ``{"kind": "mse"}``
+    - Weighted combination:
+      ``{"kind": "combined", "terms": [...], "weights": [...]}``
+
+    Args:
+        objective_config (Mapping[str, Any]): Objective config dictionary.
+        tensors (Optional[TensorMap], optional): Runtime tensor mapping used to
+            resolve mask/weights/sigma keys. Defaults to ``None``.
+
+    Raises:
+        ValueError: If the configuration is invalid.
+
+    Returns:
+        LossFn: Callable ``loss_fn(prediction, target)``.
+    """
+    if not isinstance(objective_config, Mapping):
+        raise ValueError("objective_config must be a mapping")
+
+    kind = objective_config.get("kind", "mse")
+    if kind != "combined":
+        return _build_single_loss_from_config(objective_config, tensors)
+
+    terms = objective_config.get("terms")
+    if not isinstance(terms, list) or len(terms) == 0:
+        raise ValueError("combined objective requires non-empty 'terms' list")
+
+    term_losses = [_build_single_loss_from_config(term, tensors) for term in terms]
+
+    if "weights" in objective_config:
+        weights_raw = objective_config["weights"]
+        if not isinstance(weights_raw, list):
+            raise ValueError("combined objective 'weights' must be a list")
+        weights = [float(w) for w in weights_raw]
+    else:
+        weights = [float(term.get("weight", 1.0)) for term in terms]
+
+    return combine_loss_fns(term_losses, weights=weights)
+
+
+def build_loss_from_user_config(
+    user_config: Mapping[str, Any],
+    tensors: Optional[TensorMap] = None,
+) -> Optional[LossFn]:
+    """Build an objective loss from ``user_config['inference']['objective']``.
+
+    Args:
+        user_config (Mapping[str, Any]): Full runtime user configuration.
+        tensors (Optional[TensorMap], optional): Runtime tensor mapping.
+            Defaults to ``None``.
+
+    Returns:
+        Optional[LossFn]: Configured loss function, or ``None`` if the objective
+            block is absent.
+    """
+    inference_cfg = user_config.get("inference")
+    if not isinstance(inference_cfg, Mapping):
+        return None
+
+    objective_cfg = inference_cfg.get("objective")
+    if objective_cfg is None:
+        return None
+
+    return build_loss_from_config(objective_cfg, tensors=tensors)

--- a/rubix/inference/objective_config.py
+++ b/rubix/inference/objective_config.py
@@ -91,8 +91,7 @@ def _build_single_loss_from_config(
 
     _SUPPORTED_KINDS = ("mse", "gaussian_nll", "huber")
     raise ValueError(
-        f"Unsupported objective kind '{kind}'. "
-        f"Supported kinds: {_SUPPORTED_KINDS}"
+        f"Unsupported objective kind '{kind}'. " f"Supported kinds: {_SUPPORTED_KINDS}"
     )
 
 

--- a/rubix/inference/objective_config.py
+++ b/rubix/inference/objective_config.py
@@ -89,9 +89,10 @@ def _build_single_loss_from_config(
 
         return _loss_fn
 
+    _SUPPORTED_KINDS = ("mse", "gaussian_nll", "huber")
     raise ValueError(
-        "Unsupported objective kind "
-        f"'{kind}'. Supported kinds: {'mse', 'gaussian_nll', 'huber'}"
+        f"Unsupported objective kind '{kind}'. "
+        f"Supported kinds: {_SUPPORTED_KINDS}"
     )
 
 
@@ -141,6 +142,11 @@ def build_loss_from_config(
         weights_raw = objective_config["weights"]
         if not isinstance(weights_raw, list):
             raise ValueError("combined objective 'weights' must be a list")
+        if len(weights_raw) != len(terms):
+            raise ValueError(
+                f"combined objective 'weights' length ({len(weights_raw)}) "
+                f"must match 'terms' length ({len(terms)})"
+            )
         weights = [float(w) for w in weights_raw]
     else:
         weights = [float(term.get("weight", 1.0)) for term in terms]

--- a/rubix/inference/objective_config.py
+++ b/rubix/inference/objective_config.py
@@ -129,6 +129,11 @@ def build_loss_from_config(
     terms = objective_config.get("terms")
     if not isinstance(terms, list) or len(terms) == 0:
         raise ValueError("combined objective requires non-empty 'terms' list")
+    for idx, term in enumerate(terms):
+        if not isinstance(term, Mapping):
+            raise ValueError(
+                f"combined objective term at index {idx} must be a mapping"
+            )
 
     term_losses = [_build_single_loss_from_config(term, tensors) for term in terms]
 

--- a/rubix/inference/optimize.py
+++ b/rubix/inference/optimize.py
@@ -83,6 +83,9 @@ def optimize_params(
     Args:
         pipeline (Any): Pipeline-like object consumed by :func:`rubix.inference.loss`.
         params_init (ParamsTree): Initial parameters in constrained space.
+            **Ignored when** ``state_init`` **is provided**; the optimizer
+            resumes from ``state_init.trainable_params`` instead.  Pass
+            ``None`` or any placeholder when resuming to make this explicit.
         static_data (RubixData): Baseline RubixData passed to the forward model.
         target (jnp.ndarray): Target datacube or statistic.
         learning_rate (float, optional): Step size for default Adam optimizer.
@@ -100,7 +103,9 @@ def optimize_params(
         optimizer (Optional[optax.GradientTransformation], optional): Custom
             Optax optimizer. Defaults to ``None`` (Adam with ``learning_rate``).
         state_init (Optional[OptimizationState], optional): Optional internal
-            state for exact resume. Defaults to ``None``.
+            state for exact resume.  When provided, ``params_init`` is ignored
+            and optimization continues from the persisted trainable parameters
+            and optimizer state.  Defaults to ``None``.
         return_state (bool, optional): If ``True``, also return updated
             :class:`OptimizationState`. Defaults to ``False``.
 

--- a/rubix/inference/optimize.py
+++ b/rubix/inference/optimize.py
@@ -48,6 +48,16 @@ class OptimizationResult:
     converged: bool
 
 
+@dataclass
+class OptimizationState:
+    """Serializable optimization state for checkpointing/resume."""
+
+    trainable_params: dict[str, dict[str, Any]]
+    opt_state: Any
+    best_trainable_params: dict[str, dict[str, Any]]
+    best_loss: float
+
+
 def _tree_to_dict(tree: ParamsTree) -> dict[str, dict[str, Any]]:
     """Return a mutable dictionary copy from a nested parameter tree."""
     return {component: dict(fields) for component, fields in tree.items()}
@@ -65,7 +75,9 @@ def optimize_params(
     noise_key: Optional[jnp.ndarray] = None,
     transforms: Optional[TransformTree] = None,
     optimizer: Optional[optax.GradientTransformation] = None,
-) -> OptimizationResult:
+    state_init: Optional[OptimizationState] = None,
+    return_state: bool = False,
+) -> Any:
     """Run gradient-based parameter optimization with Optax.
 
     Args:
@@ -87,6 +99,10 @@ def optimize_params(
             Defaults to ``None``.
         optimizer (Optional[optax.GradientTransformation], optional): Custom
             Optax optimizer. Defaults to ``None`` (Adam with ``learning_rate``).
+        state_init (Optional[OptimizationState], optional): Optional internal
+            state for exact resume. Defaults to ``None``.
+        return_state (bool, optional): If ``True``, also return updated
+            :class:`OptimizationState`. Defaults to ``False``.
 
     Returns:
         OptimizationResult: Final/best params, optimization traces, and the
@@ -95,16 +111,23 @@ def optimize_params(
     if optimizer is None:
         optimizer = optax.adam(learning_rate)
 
-    if transforms is None:
-        trainable_params = _tree_to_dict(params_init)
+    if state_init is None:
+        if transforms is None:
+            trainable_params = _tree_to_dict(params_init)
+        else:
+            trainable_params = apply_transforms(
+                params=params_init,
+                transforms=transforms,
+                direction="inverse",
+            )
+        opt_state = optimizer.init(trainable_params)
+        best_trainable_params = trainable_params
+        best_loss_init = jnp.array(jnp.inf)
     else:
-        trainable_params = apply_transforms(
-            params=params_init,
-            transforms=transforms,
-            direction="inverse",
-        )
-
-    opt_state = optimizer.init(trainable_params)
+        trainable_params = state_init.trainable_params
+        opt_state = state_init.opt_state
+        best_trainable_params = state_init.best_trainable_params
+        best_loss_init = jnp.asarray(state_init.best_loss)
 
     def train_loss(train_params):
         if transforms is None:
@@ -172,15 +195,23 @@ def optimize_params(
     init_carry = (
         trainable_params,
         opt_state,
-        trainable_params,
-        jnp.array(jnp.inf),
+        best_trainable_params,
+        best_loss_init,
         jnp.array(False),
     )
-    (final_params, _, final_best_params, best_loss_val, converged_flag), (
+    (
+        final_params,
+        final_opt_state,
+        final_best_params,
+        best_loss_val,
+        converged_flag,
+    ), (
         loss_arr,
         grad_norm_arr,
         update_norm_arr,
-    ) = jax.lax.scan(scan_step, init_carry, None, length=max_steps)
+    ) = jax.lax.scan(
+        scan_step, init_carry, None, length=max_steps
+    )
 
     # Detect convergence post-hoc; no device->host sync until here.
     # Because the scan freezes once `update_norm < tol`, the first True marks
@@ -216,7 +247,7 @@ def optimize_params(
             )
         )
 
-    return OptimizationResult(
+    result = OptimizationResult(
         params=result_params,
         best_params=result_best_params,
         loss_history=loss_history,
@@ -226,6 +257,17 @@ def optimize_params(
         steps_run=steps_run,
         converged=converged,
     )
+
+    state = OptimizationState(
+        trainable_params=_tree_to_dict(final_params),
+        opt_state=final_opt_state,
+        best_trainable_params=_tree_to_dict(final_best_params),
+        best_loss=float(best_loss_val),
+    )
+
+    if return_state:
+        return result, state
+    return result
 
 
 def optimize_ifu_cube(
@@ -242,7 +284,9 @@ def optimize_ifu_cube(
     noise_key: Optional[jnp.ndarray] = None,
     transforms: Optional[TransformTree] = None,
     optimizer: Optional[optax.GradientTransformation] = None,
-) -> OptimizationResult:
+    state_init: Optional[OptimizationState] = None,
+    return_state: bool = False,
+) -> Any:
     """Optimize parameters against a full IFU cube with optional weighting.
 
     Args:
@@ -267,12 +311,14 @@ def optimize_ifu_cube(
             for constrained optimization. Defaults to ``None``.
         optimizer (Optional[optax.GradientTransformation], optional): Custom
             Optax optimizer. Defaults to ``None`` (Adam with ``learning_rate``).
+        state_init (Optional[OptimizationState], optional): Optional internal
+            state for exact resume. Defaults to ``None``.
+        return_state (bool, optional): If ``True``, also return updated
+            :class:`OptimizationState`. Defaults to ``False``.
 
     Raises:
-        ValueError: If ``target`` is not a 3D IFU datacube.
-        ValueError: If ``weights`` contains non-finite values.
-        ValueError: If ``weights`` contains negative values.
-        ValueError: If ``mask`` contains negative values.
+        ValueError: If ``target`` is not 3D, or if ``weights``/``mask`` have
+            invalid values.
 
     Returns:
         OptimizationResult: Standard optimization traces and best/final params.
@@ -308,4 +354,6 @@ def optimize_ifu_cube(
         noise_key=noise_key,
         transforms=transforms,
         optimizer=optimizer,
+        state_init=state_init,
+        return_state=return_state,
     )

--- a/rubix/inference/performance_guardrails.py
+++ b/rubix/inference/performance_guardrails.py
@@ -1,0 +1,148 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from .benchmark import IFUCubeBenchmarkResult
+from .vi_benchmark import VIBenchmarkResult
+
+
+@dataclass(frozen=True)
+class RuntimeThresholds:
+    """Thresholds for runtime regression checks."""
+
+    max_mean_runtime_s: Optional[float] = None
+    max_median_runtime_s: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class ObjectiveThresholds:
+    """Thresholds for objective quality checks."""
+
+    max_final_loss: Optional[float] = None
+    max_best_loss: Optional[float] = None
+    max_final_objective: Optional[float] = None
+    max_best_objective: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class PerformanceCheckResult:
+    """Outcome of a performance guardrail check."""
+
+    passed: bool
+    message: str
+
+
+def _check_runtime(
+    mean_runtime_s: float,
+    median_runtime_s: float,
+    runtime_thresholds: RuntimeThresholds,
+) -> list[str]:
+    errors: list[str] = []
+    if runtime_thresholds.max_mean_runtime_s is not None:
+        if mean_runtime_s > runtime_thresholds.max_mean_runtime_s:
+            errors.append(
+                f"mean runtime {mean_runtime_s:.6f}s exceeds "
+                f"threshold {runtime_thresholds.max_mean_runtime_s:.6f}s"
+            )
+
+    if runtime_thresholds.max_median_runtime_s is not None:
+        if median_runtime_s > runtime_thresholds.max_median_runtime_s:
+            errors.append(
+                f"median runtime {median_runtime_s:.6f}s exceeds "
+                f"threshold {runtime_thresholds.max_median_runtime_s:.6f}s"
+            )
+
+    return errors
+
+
+def check_ifu_optimization_guardrails(
+    result: IFUCubeBenchmarkResult,
+    runtime_thresholds: RuntimeThresholds,
+    objective_thresholds: ObjectiveThresholds,
+) -> PerformanceCheckResult:
+    """Check optimization benchmark result against runtime/objective thresholds.
+
+    Args:
+        result (IFUCubeBenchmarkResult): Optimization benchmark result.
+        runtime_thresholds (RuntimeThresholds): Runtime limits.
+        objective_thresholds (ObjectiveThresholds): Objective/loss limits.
+
+    Returns:
+        PerformanceCheckResult: Pass/fail status and explanatory message.
+    """
+    errors = _check_runtime(
+        result.mean_runtime_s,
+        result.median_runtime_s,
+        runtime_thresholds,
+    )
+
+    if objective_thresholds.max_final_loss is not None:
+        if result.final_loss > objective_thresholds.max_final_loss:
+            errors.append(
+                f"final loss {result.final_loss:.6e} exceeds "
+                f"threshold {objective_thresholds.max_final_loss:.6e}"
+            )
+
+    if objective_thresholds.max_best_loss is not None:
+        if result.best_loss > objective_thresholds.max_best_loss:
+            errors.append(
+                f"best loss {result.best_loss:.6e} exceeds "
+                f"threshold {objective_thresholds.max_best_loss:.6e}"
+            )
+
+    if errors:
+        return PerformanceCheckResult(
+            passed=False,
+            message="; ".join(errors),
+        )
+
+    return PerformanceCheckResult(
+        passed=True,
+        message="optimization benchmark satisfies configured thresholds",
+    )
+
+
+def check_vi_guardrails(
+    result: VIBenchmarkResult,
+    runtime_thresholds: RuntimeThresholds,
+    objective_thresholds: ObjectiveThresholds,
+) -> PerformanceCheckResult:
+    """Check VI benchmark result against runtime/objective thresholds.
+
+    Args:
+        result (VIBenchmarkResult): VI benchmark result.
+        runtime_thresholds (RuntimeThresholds): Runtime limits.
+        objective_thresholds (ObjectiveThresholds): Objective limits.
+
+    Returns:
+        PerformanceCheckResult: Pass/fail status and explanatory message.
+    """
+    errors = _check_runtime(
+        result.mean_runtime_s,
+        result.median_runtime_s,
+        runtime_thresholds,
+    )
+
+    if objective_thresholds.max_final_objective is not None:
+        if result.final_objective > objective_thresholds.max_final_objective:
+            errors.append(
+                f"final objective {result.final_objective:.6e} exceeds "
+                f"threshold {objective_thresholds.max_final_objective:.6e}"
+            )
+
+    if objective_thresholds.max_best_objective is not None:
+        if result.best_objective > objective_thresholds.max_best_objective:
+            errors.append(
+                f"best objective {result.best_objective:.6e} exceeds "
+                f"threshold {objective_thresholds.max_best_objective:.6e}"
+            )
+
+    if errors:
+        return PerformanceCheckResult(
+            passed=False,
+            message="; ".join(errors),
+        )
+
+    return PerformanceCheckResult(
+        passed=True,
+        message="VI benchmark satisfies configured thresholds",
+    )

--- a/rubix/inference/performance_guardrails.py
+++ b/rubix/inference/performance_guardrails.py
@@ -14,11 +14,17 @@ class RuntimeThresholds:
 
 
 @dataclass(frozen=True)
-class ObjectiveThresholds:
-    """Thresholds for objective quality checks."""
+class OptimizationObjectiveThresholds:
+    """Thresholds for optimization loss quality checks."""
 
     max_final_loss: Optional[float] = None
     max_best_loss: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class VIObjectiveThresholds:
+    """Thresholds for variational inference objective quality checks."""
+
     max_final_objective: Optional[float] = None
     max_best_objective: Optional[float] = None
 
@@ -57,14 +63,14 @@ def _check_runtime(
 def check_ifu_optimization_guardrails(
     result: IFUCubeBenchmarkResult,
     runtime_thresholds: RuntimeThresholds,
-    objective_thresholds: ObjectiveThresholds,
+    objective_thresholds: OptimizationObjectiveThresholds,
 ) -> PerformanceCheckResult:
     """Check optimization benchmark result against runtime/objective thresholds.
 
     Args:
         result (IFUCubeBenchmarkResult): Optimization benchmark result.
         runtime_thresholds (RuntimeThresholds): Runtime limits.
-        objective_thresholds (ObjectiveThresholds): Objective/loss limits.
+        objective_thresholds (OptimizationObjectiveThresholds): Loss limits.
 
     Returns:
         PerformanceCheckResult: Pass/fail status and explanatory message.
@@ -104,14 +110,14 @@ def check_ifu_optimization_guardrails(
 def check_vi_guardrails(
     result: VIBenchmarkResult,
     runtime_thresholds: RuntimeThresholds,
-    objective_thresholds: ObjectiveThresholds,
+    objective_thresholds: VIObjectiveThresholds,
 ) -> PerformanceCheckResult:
     """Check VI benchmark result against runtime/objective thresholds.
 
     Args:
         result (VIBenchmarkResult): VI benchmark result.
         runtime_thresholds (RuntimeThresholds): Runtime limits.
-        objective_thresholds (ObjectiveThresholds): Objective limits.
+        objective_thresholds (VIObjectiveThresholds): Objective limits.
 
     Returns:
         PerformanceCheckResult: Pass/fail status and explanatory message.

--- a/rubix/inference/posterior_predictive.py
+++ b/rubix/inference/posterior_predictive.py
@@ -50,8 +50,7 @@ def sample_posterior_predictive_cubes(
     base_key = jax.random.PRNGKey(seed)
     sample_keys = jax.random.split(base_key, num_samples)
 
-    cubes = []
-    for key in sample_keys:
+    def _single_sample(key):
         sampled_unconstrained = sample_diag_gaussian(
             mean=posterior_mean_params,
             log_std=posterior_log_std_params,
@@ -65,16 +64,14 @@ def sample_posterior_predictive_cubes(
                 transforms=transforms,
                 direction="forward",
             )
-        cubes.append(
-            forward(
-                pipeline=pipeline,
-                params=sampled_constrained,
-                static_data=static_data,
-                noise_key=noise_key,
-            )
+        return forward(
+            pipeline=pipeline,
+            params=sampled_constrained,
+            static_data=static_data,
+            noise_key=noise_key,
         )
 
-    return jnp.stack(cubes, axis=0)
+    return jax.lax.map(_single_sample, sample_keys)
 
 
 def summarize_predictive_cube_samples(samples: jnp.ndarray) -> dict[str, jnp.ndarray]:

--- a/rubix/inference/posterior_predictive.py
+++ b/rubix/inference/posterior_predictive.py
@@ -1,0 +1,212 @@
+from typing import Any, Mapping, Optional
+
+import jax
+import jax.numpy as jnp
+
+from rubix.core.data import RubixData
+
+from .api import LossFn, forward
+from .parameterization import TransformTree, apply_transforms
+from .variational import sample_diag_gaussian
+
+ParamsTree = Mapping[str, Mapping[str, Any]]
+
+
+def sample_posterior_predictive_cubes(
+    pipeline: Any,
+    posterior_mean_params: ParamsTree,
+    posterior_log_std_params: ParamsTree,
+    static_data: RubixData,
+    num_samples: int,
+    transforms: Optional[TransformTree] = None,
+    noise_key: Optional[jnp.ndarray] = None,
+    seed: int = 0,
+) -> jnp.ndarray:
+    """Draw posterior predictive cubes from a diagonal Gaussian posterior.
+
+    Args:
+        pipeline (Any): Pipeline-like object exposing ``run_sharded``.
+        posterior_mean_params (ParamsTree): Mean parameters in unconstrained
+            space.
+        posterior_log_std_params (ParamsTree): Log-std parameters in
+            unconstrained space.
+        static_data (RubixData): Baseline model data.
+        num_samples (int): Number of posterior predictive draws.
+        transforms (Optional[TransformTree], optional): Optional transform tree
+            to constrained space. Defaults to ``None``.
+        noise_key (Optional[jnp.ndarray], optional): Optional noise key passed
+            to each forward pass. Defaults to ``None``.
+        seed (int, optional): Random seed. Defaults to 0.
+
+    Raises:
+        ValueError: If ``num_samples`` is not strictly positive.
+
+    Returns:
+        jnp.ndarray: Predictive samples stacked as ``(num_samples, *cube_shape)``.
+    """
+    if num_samples <= 0:
+        raise ValueError("num_samples must be strictly positive")
+
+    base_key = jax.random.PRNGKey(seed)
+    sample_keys = jax.random.split(base_key, num_samples)
+
+    cubes = []
+    for key in sample_keys:
+        sampled_unconstrained = sample_diag_gaussian(
+            mean=posterior_mean_params,
+            log_std=posterior_log_std_params,
+            key=key,
+        )
+        if transforms is None:
+            sampled_constrained = sampled_unconstrained
+        else:
+            sampled_constrained = apply_transforms(
+                params=sampled_unconstrained,
+                transforms=transforms,
+                direction="forward",
+            )
+        cubes.append(
+            forward(
+                pipeline=pipeline,
+                params=sampled_constrained,
+                static_data=static_data,
+                noise_key=noise_key,
+            )
+        )
+
+    return jnp.stack(cubes, axis=0)
+
+
+def summarize_predictive_cube_samples(samples: jnp.ndarray) -> dict[str, jnp.ndarray]:
+    """Summarize predictive cube samples via moments and quantiles.
+
+    Args:
+        samples (jnp.ndarray): Predictive cubes with leading sample axis.
+
+    Raises:
+        ValueError: If ``samples`` does not include a sample axis.
+
+    Returns:
+        dict[str, jnp.ndarray]: Summary maps with keys ``mean``, ``std``,
+        ``p16``, ``p50``, and ``p84``.
+    """
+    if samples.ndim < 2:
+        raise ValueError("samples must include a leading sample axis")
+
+    return {
+        "mean": jnp.mean(samples, axis=0),
+        "std": jnp.std(samples, axis=0),
+        "p16": jnp.percentile(samples, 16.0, axis=0),
+        "p50": jnp.percentile(samples, 50.0, axis=0),
+        "p84": jnp.percentile(samples, 84.0, axis=0),
+    }
+
+
+def compute_residual_products(
+    prediction: jnp.ndarray,
+    target: jnp.ndarray,
+    sigma: Optional[jnp.ndarray] = None,
+    inv_variance: Optional[jnp.ndarray] = None,
+    mask: Optional[jnp.ndarray] = None,
+) -> dict[str, jnp.ndarray]:
+    """Compute residual, absolute residual, and chi2-like products.
+
+    Args:
+        prediction (jnp.ndarray): Predicted IFU cube.
+        target (jnp.ndarray): Target IFU cube with matching shape.
+        sigma (Optional[jnp.ndarray], optional): Per-voxel sigma cube.
+            Defaults to ``None``.
+        inv_variance (Optional[jnp.ndarray], optional): Per-voxel inverse
+            variance cube. Defaults to ``None``.
+        mask (Optional[jnp.ndarray], optional): Optional binary mask.
+            Defaults to ``None``.
+
+    Raises:
+        ValueError: If shapes are inconsistent or both ``sigma`` and
+            ``inv_variance`` are provided.
+
+    Returns:
+        dict[str, jnp.ndarray]: Residual-derived maps.
+    """
+    if prediction.shape != target.shape:
+        raise ValueError("prediction and target must have the same shape")
+
+    if sigma is not None and sigma.shape != target.shape:
+        raise ValueError("sigma must have the same shape as target")
+
+    if inv_variance is not None and inv_variance.shape != target.shape:
+        raise ValueError("inv_variance must have the same shape as target")
+
+    if mask is not None and mask.shape != target.shape:
+        raise ValueError("mask must have the same shape as target")
+
+    if sigma is not None and inv_variance is not None:
+        raise ValueError("provide only one of sigma or inv_variance")
+
+    residual = prediction - target
+    abs_residual = jnp.abs(residual)
+
+    if inv_variance is not None:
+        chi2 = residual**2 * inv_variance
+    elif sigma is not None:
+        chi2 = residual**2 / jnp.maximum(sigma**2, jnp.asarray(1e-12, sigma.dtype))
+    else:
+        chi2 = residual**2
+
+    if mask is None:
+        mask_f = jnp.ones_like(residual)
+    else:
+        mask_f = mask.astype(residual.dtype)
+
+    return {
+        "residual": residual,
+        "abs_residual": abs_residual,
+        "chi2": chi2,
+        "masked_residual": residual * mask_f,
+        "masked_chi2": chi2 * mask_f,
+    }
+
+
+def summarize_masked_metrics(
+    prediction: jnp.ndarray,
+    target: jnp.ndarray,
+    mask: Optional[jnp.ndarray] = None,
+    loss_fn: Optional[LossFn] = None,
+) -> dict[str, float]:
+    """Compute scalar masked summary metrics for science reporting.
+
+    Args:
+        prediction (jnp.ndarray): Predicted IFU cube.
+        target (jnp.ndarray): Target IFU cube.
+        mask (Optional[jnp.ndarray], optional): Optional binary mask.
+            Defaults to ``None``.
+        loss_fn (Optional[LossFn], optional): Optional custom scalar loss.
+            Defaults to ``None``.
+
+    Raises:
+        ValueError: If prediction/target shapes (or mask shape) are invalid.
+
+    Returns:
+        dict[str, float]: Summary metrics including ``mse``, ``mae``, and
+        optionally ``custom_loss``.
+    """
+    if prediction.shape != target.shape:
+        raise ValueError("prediction and target must have the same shape")
+
+    if mask is not None and mask.shape != target.shape:
+        raise ValueError("mask must have the same shape as target")
+
+    residual = prediction - target
+    if mask is None:
+        mask_f = jnp.ones_like(residual)
+    else:
+        mask_f = mask.astype(residual.dtype)
+
+    denom = jnp.maximum(jnp.sum(mask_f), jnp.asarray(1e-12, dtype=residual.dtype))
+    mse = jnp.sum((residual**2) * mask_f) / denom
+    mae = jnp.sum(jnp.abs(residual) * mask_f) / denom
+
+    metrics = {"mse": float(mse), "mae": float(mae)}
+    if loss_fn is not None:
+        metrics["custom_loss"] = float(loss_fn(prediction, target))
+    return metrics

--- a/rubix/inference/posterior_predictive.py
+++ b/rubix/inference/posterior_predictive.py
@@ -147,9 +147,11 @@ def compute_residual_products(
     abs_residual = jnp.abs(residual)
 
     if inv_variance is not None:
-        chi2 = residual**2 * inv_variance
+        chi2 = residual**2 * inv_variance.astype(residual.dtype)
     elif sigma is not None:
-        chi2 = residual**2 / jnp.maximum(sigma**2, jnp.asarray(1e-12, sigma.dtype))
+        eps_arr = jnp.asarray(1e-12, dtype=residual.dtype)
+        sigma_safe = jnp.maximum(sigma.astype(residual.dtype), eps_arr)
+        chi2 = residual**2 / (sigma_safe**2)
     else:
         chi2 = residual**2
 

--- a/rubix/inference/variational.py
+++ b/rubix/inference/variational.py
@@ -235,7 +235,7 @@ def optimize_variational_posterior(
         steps_run = int(state_init.steps_run)
 
     converged = False
-    step_offset = steps_run
+    initial_steps_run = steps_run
 
     def objective_fn(current_params, step_key):
         current_mean = current_params["mean"]
@@ -279,7 +279,7 @@ def optimize_variational_posterior(
         if value < best_objective:
             best_objective = value
             best_mean = current_mean
-            best_step = step_offset + step
+            best_step = initial_steps_run + step
 
         updates, opt_state = optimizer.update(grads, opt_state, variational_params)
         variational_params = optax.apply_updates(variational_params, updates)

--- a/rubix/inference/variational.py
+++ b/rubix/inference/variational.py
@@ -146,6 +146,8 @@ def optimize_variational_posterior(
     Args:
         pipeline (Any): Pipeline-like object consumed by :func:`rubix.inference.loss`.
         params_init (ParamsTree): Initial constrained parameter point.
+            **Ignored when** ``state_init`` **is provided**; the optimizer
+            resumes from ``state_init.variational_params`` instead.
         static_data (RubixData): Baseline RubixData passed to the forward model.
         target (jnp.ndarray): Target datacube or statistic.
         learning_rate (float, optional): Step size for default Adam optimizer.
@@ -155,7 +157,9 @@ def optimize_variational_posterior(
             Defaults to 1e-6.
         num_samples (int, optional): Monte Carlo samples per step. Defaults to 4.
         beta_kl (float, optional): KL weight. Defaults to 1e-3.
-        init_log_std (float, optional): Initial posterior log-std. Defaults to -2.0.
+        init_log_std (float, optional): Initial posterior log-std.  **Ignored
+            when** ``state_init`` **is provided**; the posterior is resumed
+            from the persisted variational parameters.  Defaults to -2.0.
         loss_fn (Optional[LossFn], optional): Optional custom reconstruction loss.
             Defaults to ``None`` (sum-of-squares).
         noise_key (Optional[jnp.ndarray], optional): Optional key for stochastic
@@ -165,9 +169,14 @@ def optimize_variational_posterior(
             Defaults to ``None``.
         optimizer (Optional[optax.GradientTransformation], optional): Custom
             optimizer. Defaults to ``None`` (Adam).
-        seed (int, optional): Random seed for VI sampling. Defaults to 0.
+        seed (int, optional): Random seed for VI sampling.  **Ignored when**
+            ``state_init`` **is provided**; the PRNG key is resumed from
+            ``state_init.key``.  Defaults to 0.
         state_init (Optional[VariationalState], optional): Optional resumable
-            variational state. Defaults to ``None``.
+            variational state.  When provided, ``params_init``, ``init_log_std``,
+            and ``seed`` are all ignored and the run continues exactly from the
+            persisted variational parameters, optimizer state, and PRNG key.
+            Defaults to ``None``.
         return_state (bool, optional): If ``True``, also return updated
             :class:`VariationalState`. Defaults to ``False``.
 
@@ -226,6 +235,7 @@ def optimize_variational_posterior(
         steps_run = int(state_init.steps_run)
 
     converged = False
+    step_offset = steps_run
 
     def objective_fn(current_params, step_key):
         current_mean = current_params["mean"]
@@ -269,7 +279,7 @@ def optimize_variational_posterior(
         if value < best_objective:
             best_objective = value
             best_mean = current_mean
-            best_step = steps_run + step
+            best_step = step_offset + step
 
         updates, opt_state = optimizer.update(grads, opt_state, variational_params)
         variational_params = optax.apply_updates(variational_params, updates)
@@ -310,7 +320,13 @@ def optimize_variational_posterior(
         final_objective = float("nan")
         final_reconstruction = float("nan")
         final_kl = float("nan")
+        state_key = key
     else:
+        # Capture the training-loop key state before the final evaluation so
+        # that the VariationalState records the PRNG state at which the loop
+        # ended.  This ensures resumed runs continue with the same key
+        # sequence as a continuous run of the same total length would.
+        state_key = key
         key, final_eval_key = jax.random.split(key)
         final_value, (final_reconstruction_value, final_kl_value) = objective_fn(
             variational_params, final_eval_key
@@ -347,7 +363,7 @@ def optimize_variational_posterior(
         best_mean=_tree_to_dict(best_mean),
         best_objective=float(best_objective),
         best_step=best_step,
-        key=key,
+        key=state_key,
         objective_history=objective_history,
         reconstruction_history=reconstruction_history,
         kl_history=kl_history,

--- a/rubix/inference/variational.py
+++ b/rubix/inference/variational.py
@@ -38,6 +38,24 @@ class VariationalResult:
     converged: bool = False
 
 
+@dataclass
+class VariationalState:
+    """Serializable variational optimization state for checkpoint/resume."""
+
+    variational_params: dict[str, dict[str, dict[str, Any]]]
+    opt_state: Any
+    best_mean: dict[str, dict[str, Any]]
+    best_objective: float
+    best_step: int
+    key: jnp.ndarray
+    objective_history: list[float]
+    reconstruction_history: list[float]
+    kl_history: list[float]
+    grad_norm_history: list[float]
+    update_norm_history: list[float]
+    steps_run: int
+
+
 def _tree_to_dict(tree: ParamsTree) -> dict[str, dict[str, Any]]:
     """Return a mutable dictionary copy from a nested parameter tree."""
     return {component: dict(fields) for component, fields in tree.items()}
@@ -120,7 +138,9 @@ def optimize_variational_posterior(
     transforms: Optional[TransformTree] = None,
     optimizer: Optional[optax.GradientTransformation] = None,
     seed: int = 0,
-) -> VariationalResult:
+    state_init: Optional[VariationalState] = None,
+    return_state: bool = False,
+) -> Any:
     """Optimize a mean-field variational posterior with reparameterization.
 
     Args:
@@ -146,6 +166,10 @@ def optimize_variational_posterior(
         optimizer (Optional[optax.GradientTransformation], optional): Custom
             optimizer. Defaults to ``None`` (Adam).
         seed (int, optional): Random seed for VI sampling. Defaults to 0.
+        state_init (Optional[VariationalState], optional): Optional resumable
+            variational state. Defaults to ``None``.
+        return_state (bool, optional): If ``True``, also return updated
+            :class:`VariationalState`. Defaults to ``False``.
 
     Raises:
         ValueError: If ``num_samples`` is not strictly positive.
@@ -159,34 +183,49 @@ def optimize_variational_posterior(
     if optimizer is None:
         optimizer = optax.adam(learning_rate)
 
-    if transforms is None:
-        unconstrained_init = _tree_to_dict(params_init)
-    else:
-        unconstrained_init = apply_transforms(
-            params=params_init,
-            transforms=transforms,
-            direction="inverse",
+    if state_init is None:
+        if transforms is None:
+            unconstrained_init = _tree_to_dict(params_init)
+        else:
+            unconstrained_init = apply_transforms(
+                params=params_init,
+                transforms=transforms,
+                direction="inverse",
+            )
+
+        mean, log_std = initialize_mean_field_params(
+            params_init=unconstrained_init,
+            init_log_std=init_log_std,
         )
+        variational_params = {"mean": mean, "log_std": log_std}
+        opt_state = optimizer.init(variational_params)
 
-    mean, log_std = initialize_mean_field_params(
-        params_init=unconstrained_init,
-        init_log_std=init_log_std,
-    )
-    variational_params = {"mean": mean, "log_std": log_std}
-    opt_state = optimizer.init(variational_params)
+        objective_history: list[float] = []
+        reconstruction_history: list[float] = []
+        kl_history: list[float] = []
+        grad_norm_history: list[float] = []
+        update_norm_history: list[float] = []
 
-    objective_history: list[float] = []
-    reconstruction_history: list[float] = []
-    kl_history: list[float] = []
-    grad_norm_history: list[float] = []
-    update_norm_history: list[float] = []
+        best_objective = jnp.inf
+        best_mean = mean
+        best_step = -1
+        steps_run = 0
+        key = jax.random.PRNGKey(seed)
+    else:
+        variational_params = state_init.variational_params
+        opt_state = state_init.opt_state
+        best_mean = state_init.best_mean
+        best_objective = jnp.asarray(state_init.best_objective)
+        best_step = int(state_init.best_step)
+        key = state_init.key
+        objective_history = list(state_init.objective_history)
+        reconstruction_history = list(state_init.reconstruction_history)
+        kl_history = list(state_init.kl_history)
+        grad_norm_history = list(state_init.grad_norm_history)
+        update_norm_history = list(state_init.update_norm_history)
+        steps_run = int(state_init.steps_run)
 
-    best_objective = jnp.inf
-    best_mean = mean
-    best_step = -1
     converged = False
-    steps_run = 0
-    key = jax.random.PRNGKey(seed)
 
     def objective_fn(current_params, step_key):
         current_mean = current_params["mean"]
@@ -230,7 +269,7 @@ def optimize_variational_posterior(
         if value < best_objective:
             best_objective = value
             best_mean = current_mean
-            best_step = step
+            best_step = steps_run + step
 
         updates, opt_state = optimizer.update(grads, opt_state, variational_params)
         variational_params = optax.apply_updates(variational_params, updates)
@@ -244,7 +283,7 @@ def optimize_variational_posterior(
         grad_norm_history.append(grad_norm)
         update_norm_history.append(update_norm)
 
-        steps_run = step + 1
+        steps_run = steps_run + 1
         if update_norm < tol:
             converged = True
             break
@@ -280,7 +319,7 @@ def optimize_variational_posterior(
         final_reconstruction = float(final_reconstruction_value)
         final_kl = float(final_kl_value)
 
-    return VariationalResult(
+    result = VariationalResult(
         posterior_mean_params=_tree_to_dict(final_mean),
         posterior_log_std_params=_tree_to_dict(final_log_std),
         posterior_mean_constrained_params=_tree_to_dict(posterior_mean_constrained),
@@ -301,6 +340,25 @@ def optimize_variational_posterior(
         steps_run=steps_run,
         converged=converged,
     )
+
+    state = VariationalState(
+        variational_params=_tree_to_dict(variational_params),
+        opt_state=opt_state,
+        best_mean=_tree_to_dict(best_mean),
+        best_objective=float(best_objective),
+        best_step=best_step,
+        key=key,
+        objective_history=objective_history,
+        reconstruction_history=reconstruction_history,
+        kl_history=kl_history,
+        grad_norm_history=grad_norm_history,
+        update_norm_history=update_norm_history,
+        steps_run=steps_run,
+    )
+
+    if return_state:
+        return result, state
+    return result
 
 
 def optimize_variational_ifu_cube(
@@ -324,7 +382,9 @@ def optimize_variational_ifu_cube(
     transforms: Optional[TransformTree] = None,
     optimizer: Optional[optax.GradientTransformation] = None,
     seed: int = 0,
-) -> VariationalResult:
+    state_init: Optional[VariationalState] = None,
+    return_state: bool = False,
+) -> Any:
     """Optimize a VI posterior against full IFU cubes with science losses.
 
     Args:
@@ -358,6 +418,10 @@ def optimize_variational_ifu_cube(
         optimizer (Optional[optax.GradientTransformation], optional): Optional
             optimizer override. Defaults to ``None``.
         seed (int, optional): Random seed for VI sampling. Defaults to 0.
+        state_init (Optional[VariationalState], optional): Optional resumable
+            state for exact continuation. Defaults to ``None``.
+        return_state (bool, optional): If ``True``, also return updated
+            :class:`VariationalState`. Defaults to ``False``.
 
     Raises:
         ValueError: If ``target`` is not 3D, if Huber settings are invalid, if
@@ -371,9 +435,7 @@ def optimize_variational_ifu_cube(
         raise ValueError("target must be a 3D IFU datacube")
 
     if sigma is not None and inv_variance is not None:
-        raise ValueError(
-            "only one of sigma or inv_variance may be provided, not both"
-        )
+        raise ValueError("only one of sigma or inv_variance may be provided, not both")
 
     if sigma is not None and sigma.shape != target.shape:
         raise ValueError(
@@ -439,4 +501,6 @@ def optimize_variational_ifu_cube(
         transforms=transforms,
         optimizer=optimizer,
         seed=seed,
+        state_init=state_init,
+        return_state=return_state,
     )

--- a/rubix/inference/workflows.py
+++ b/rubix/inference/workflows.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jax.numpy as jnp
+import numpy as np
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+
+from .optimize import optimize_ifu_cube
+from .posterior_predictive import (
+    compute_residual_products,
+    sample_posterior_predictive_cubes,
+    summarize_masked_metrics,
+    summarize_predictive_cube_samples,
+)
+from .variational import optimize_variational_ifu_cube
+
+
+class SyntheticScalePipeline:
+    """Simple synthetic IFU pipeline used by the science recipe workflow."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _make_static_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([0.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Convert nested JAX/NumPy containers into JSON-serializable values."""
+    if isinstance(value, dict):
+        return {k: _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(v) for v in value]
+    if isinstance(value, np.ndarray):
+        if value.ndim == 0:
+            return value.item()
+        return value.tolist()
+    if isinstance(value, jnp.ndarray):
+        arr = np.asarray(value)
+        if arr.ndim == 0:
+            return arr.item()
+        return arr.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def run_synthetic_science_recipe(
+    cube_shape: tuple[int, int, int] = (4, 4, 16),
+    target_scale: float = 1.7,
+    optimize_steps: int = 120,
+    vi_steps: int = 120,
+    num_vi_samples: int = 4,
+    num_posterior_draws: int = 8,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Run a compact end-to-end synthetic science workflow.
+
+    This workflow performs deterministic optimization, variational inference,
+    posterior predictive sampling, and residual/metric summarization.
+
+    Args:
+        cube_shape (tuple[int, int, int], optional): Synthetic IFU cube shape
+            ``(nx, ny, nw)``. Defaults to ``(4, 4, 16)``.
+        target_scale (float, optional): Multiplicative scale for the synthetic
+            target cube. Defaults to 1.7.
+        optimize_steps (int, optional): Maximum deterministic optimization
+            steps. Defaults to 120.
+        vi_steps (int, optional): Maximum variational optimization steps.
+            Defaults to 120.
+        num_vi_samples (int, optional): Monte Carlo samples per VI step.
+            Defaults to 4.
+        num_posterior_draws (int, optional): Number of posterior predictive
+            cube draws. Defaults to 8.
+        seed (int, optional): Random seed for VI and predictive sampling.
+            Defaults to 0.
+
+    Returns:
+        dict[str, Any]: Workflow outputs and diagnostic summaries.
+    """
+    template = jnp.ones(cube_shape, dtype=jnp.float32)
+    target = target_scale * template
+
+    pipeline = SyntheticScalePipeline(template)
+    static_data = _make_static_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+
+    opt_result = optimize_ifu_cube(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=0.1,
+        max_steps=optimize_steps,
+        tol=1e-8,
+    )
+
+    vi_result = optimize_variational_ifu_cube(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        sigma=jnp.ones_like(target),
+        learning_rate=5e-2,
+        max_steps=vi_steps,
+        tol=1e-8,
+        num_samples=num_vi_samples,
+        beta_kl=1e-4,
+        seed=seed,
+    )
+
+    predictive_samples = sample_posterior_predictive_cubes(
+        pipeline=pipeline,
+        posterior_mean_params=vi_result.posterior_mean_params,
+        posterior_log_std_params=vi_result.posterior_log_std_params,
+        static_data=static_data,
+        num_samples=num_posterior_draws,
+        seed=seed + 1,
+    )
+    predictive_summary = summarize_predictive_cube_samples(predictive_samples)
+    residual_products = compute_residual_products(
+        prediction=predictive_summary["mean"],
+        target=target,
+    )
+    metrics = summarize_masked_metrics(
+        prediction=predictive_summary["mean"],
+        target=target,
+    )
+
+    return {
+        "config": {
+            "cube_shape": cube_shape,
+            "target_scale": target_scale,
+            "optimize_steps": optimize_steps,
+            "vi_steps": vi_steps,
+            "num_vi_samples": num_vi_samples,
+            "num_posterior_draws": num_posterior_draws,
+            "seed": seed,
+        },
+        "optimization": {
+            "final_loss": opt_result.final_loss,
+            "best_loss": opt_result.best_loss,
+            "steps_run": opt_result.steps_run,
+            "converged": opt_result.converged,
+        },
+        "variational": {
+            "final_objective": vi_result.final_objective,
+            "best_objective": vi_result.best_objective,
+            "steps_run": vi_result.steps_run,
+            "converged": vi_result.converged,
+        },
+        "predictive_summary": predictive_summary,
+        "residual_products": residual_products,
+        "metrics": metrics,
+    }
+
+
+def save_science_recipe_outputs(
+    outputs: dict[str, Any],
+    output_dir: str,
+) -> None:
+    """Persist workflow outputs to JSON and NPZ files.
+
+    Args:
+        outputs (dict[str, Any]): Outputs from
+            :func:`run_synthetic_science_recipe`.
+        output_dir (str): Destination directory.
+    """
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = {
+        "config": outputs["config"],
+        "optimization": outputs["optimization"],
+        "variational": outputs["variational"],
+        "metrics": outputs["metrics"],
+    }
+    json_summary = _to_jsonable(summary)
+    (out_dir / "summary.json").write_text(
+        json.dumps(json_summary, indent=2), encoding="utf-8"
+    )
+
+    predictive_np = {k: np.asarray(v) for k, v in outputs["predictive_summary"].items()}
+    residual_np = {k: np.asarray(v) for k, v in outputs["residual_products"].items()}
+
+    np.savez(out_dir / "predictive_summary.npz", **predictive_np)
+    np.savez(out_dir / "residual_products.npz", **residual_np)

--- a/scripts/run_synthetic_science_recipe.py
+++ b/scripts/run_synthetic_science_recipe.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import argparse
+
+from rubix.inference.workflows import (
+    run_synthetic_science_recipe,
+    save_science_recipe_outputs,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run synthetic end-to-end science workflow and save outputs."
+    )
+    parser.add_argument("--output-dir", type=str, default="outputs/science_recipe")
+    parser.add_argument("--nx", type=int, default=4)
+    parser.add_argument("--ny", type=int, default=4)
+    parser.add_argument("--nw", type=int, default=16)
+    parser.add_argument("--target-scale", type=float, default=1.7)
+    parser.add_argument("--optimize-steps", type=int, default=120)
+    parser.add_argument("--vi-steps", type=int, default=120)
+    parser.add_argument("--num-vi-samples", type=int, default=4)
+    parser.add_argument("--num-posterior-draws", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    outputs = run_synthetic_science_recipe(
+        cube_shape=(args.nx, args.ny, args.nw),
+        target_scale=args.target_scale,
+        optimize_steps=args.optimize_steps,
+        vi_steps=args.vi_steps,
+        num_vi_samples=args.num_vi_samples,
+        num_posterior_draws=args.num_posterior_draws,
+        seed=args.seed,
+    )
+    save_science_recipe_outputs(outputs, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_inference_checkpoint.py
+++ b/tests/test_inference_checkpoint.py
@@ -69,7 +69,10 @@ def test_optimize_state_resume_matches_single_run(tmp_path):
     )
 
     ckpt_path = tmp_path / "opt.pkl"
-    save_checkpoint(ckpt_path, make_optimization_checkpoint(first, state))
+    save_checkpoint(
+        ckpt_path,
+        make_optimization_checkpoint(first, state, learning_rate=0.1, tol=1e-8),
+    )
     ckpt = load_checkpoint(ckpt_path)
 
     resumed, _ = resume_optimization_from_checkpoint(
@@ -77,9 +80,7 @@ def test_optimize_state_resume_matches_single_run(tmp_path):
         pipeline=pipeline,
         static_data=static_data,
         target=target,
-        learning_rate=0.1,
         max_steps=20,
-        tol=1e-8,
     )
 
     assert jnp.allclose(resumed.final_loss, full.final_loss)
@@ -121,7 +122,18 @@ def test_variational_state_resume_matches_single_run(tmp_path):
     )
 
     ckpt_path = tmp_path / "vi.pkl"
-    save_checkpoint(ckpt_path, make_variational_checkpoint(first, state))
+    save_checkpoint(
+        ckpt_path,
+        make_variational_checkpoint(
+            first,
+            state,
+            learning_rate=5e-2,
+            tol=1e-8,
+            num_samples=4,
+            beta_kl=1e-4,
+            seed=11,
+        ),
+    )
     ckpt = load_checkpoint(ckpt_path)
 
     resumed, _ = resume_variational_from_checkpoint(
@@ -129,12 +141,7 @@ def test_variational_state_resume_matches_single_run(tmp_path):
         pipeline=pipeline,
         static_data=static_data,
         target=target,
-        learning_rate=5e-2,
         max_steps=20,
-        tol=1e-8,
-        num_samples=4,
-        beta_kl=1e-4,
-        seed=11,
     )
 
     assert jnp.allclose(resumed.final_objective, full.final_objective)

--- a/tests/test_inference_checkpoint.py
+++ b/tests/test_inference_checkpoint.py
@@ -1,0 +1,140 @@
+import jax.numpy as jnp
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import (
+    load_checkpoint,
+    make_optimization_checkpoint,
+    make_variational_checkpoint,
+    optimize_params,
+    optimize_variational_posterior,
+    resume_optimization_from_checkpoint,
+    resume_variational_from_checkpoint,
+    save_checkpoint,
+)
+
+
+class DummyPipeline:
+    """Simple differentiable pipeline for checkpoint tests."""
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        value = jnp.sum(rubixdata.stars.age) + 2.0 * jnp.sum(
+            rubixdata.stars.metallicity
+        )
+        return jnp.reshape(value, (1, 1, 1))
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([1.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_optimize_state_resume_matches_single_run(tmp_path):
+    pipeline = DummyPipeline()
+    static_data = _make_rubix_data()
+    params_init = {"stars": {"age": jnp.array([0.0]), "metallicity": jnp.array([0.0])}}
+    target = jnp.array([[[5.0]]])
+
+    full = optimize_params(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=0.1,
+        max_steps=40,
+        tol=1e-8,
+    )
+
+    first, state = optimize_params(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=0.1,
+        max_steps=20,
+        tol=1e-8,
+        return_state=True,
+    )
+
+    ckpt_path = tmp_path / "opt.pkl"
+    save_checkpoint(ckpt_path, make_optimization_checkpoint(first, state))
+    ckpt = load_checkpoint(ckpt_path)
+
+    resumed, _ = resume_optimization_from_checkpoint(
+        ckpt,
+        pipeline=pipeline,
+        static_data=static_data,
+        target=target,
+        learning_rate=0.1,
+        max_steps=20,
+        tol=1e-8,
+    )
+
+    assert jnp.allclose(resumed.final_loss, full.final_loss)
+
+
+def test_variational_state_resume_matches_single_run(tmp_path):
+    pipeline = DummyPipeline()
+    static_data = _make_rubix_data()
+    params_init = {
+        "stars": {"age": jnp.array([0.5]), "metallicity": jnp.array([0.001])}
+    }
+    target = jnp.array([[[5.0]]])
+
+    full = optimize_variational_posterior(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=5e-2,
+        max_steps=40,
+        tol=1e-8,
+        num_samples=4,
+        beta_kl=1e-4,
+        seed=11,
+    )
+
+    first, state = optimize_variational_posterior(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=5e-2,
+        max_steps=20,
+        tol=1e-8,
+        num_samples=4,
+        beta_kl=1e-4,
+        seed=11,
+        return_state=True,
+    )
+
+    ckpt_path = tmp_path / "vi.pkl"
+    save_checkpoint(ckpt_path, make_variational_checkpoint(first, state))
+    ckpt = load_checkpoint(ckpt_path)
+
+    resumed, _ = resume_variational_from_checkpoint(
+        ckpt,
+        pipeline=pipeline,
+        static_data=static_data,
+        target=target,
+        learning_rate=5e-2,
+        max_steps=20,
+        tol=1e-8,
+        num_samples=4,
+        beta_kl=1e-4,
+        seed=11,
+    )
+
+    assert jnp.allclose(resumed.final_objective, full.final_objective)

--- a/tests/test_inference_objective_config.py
+++ b/tests/test_inference_objective_config.py
@@ -64,6 +64,16 @@ def test_build_loss_from_user_config_absent_objective_returns_none():
     assert build_loss_from_user_config(cfg) is None
 
 
+def test_build_loss_from_config_rejects_weights_length_mismatch():
+    cfg = {
+        "kind": "combined",
+        "terms": [{"kind": "mse"}, {"kind": "huber"}],
+        "weights": [0.5],
+    }
+    with pytest.raises(ValueError, match="'weights' length"):
+        build_loss_from_config(cfg)
+
+
 def test_build_loss_from_user_config_resolves_objective():
     cfg = {
         "inference": {

--- a/tests/test_inference_objective_config.py
+++ b/tests/test_inference_objective_config.py
@@ -1,0 +1,84 @@
+import jax.numpy as jnp
+import pytest
+
+from rubix.inference import build_loss_from_config, build_loss_from_user_config
+
+
+def test_build_loss_from_config_single_mse_matches_expected():
+    cfg = {"kind": "mse", "normalize": True}
+    loss_fn = build_loss_from_config(cfg)
+
+    pred = jnp.array([[[2.0, 0.0]]])
+    target = jnp.array([[[1.0, 2.0]]])
+    value = loss_fn(pred, target)
+
+    expected = (1.0**2 + (-2.0) ** 2) / 2.0
+    assert jnp.allclose(value, expected)
+
+
+def test_build_loss_from_config_combined_with_tensor_keys():
+    cfg = {
+        "kind": "combined",
+        "terms": [
+            {
+                "kind": "gaussian_nll",
+                "inv_variance_key": "ivar",
+                "mask_key": "mask",
+                "normalize": True,
+            },
+            {
+                "kind": "huber",
+                "delta": 1.0,
+                "mask_key": "mask",
+                "weight": 0.25,
+                "normalize": True,
+            },
+        ],
+    }
+
+    tensors = {
+        "ivar": jnp.array([[[4.0, 1.0]]]),
+        "mask": jnp.array([[[1.0, 0.0]]]),
+    }
+
+    loss_fn = build_loss_from_config(cfg, tensors=tensors)
+    pred = jnp.array([[[2.0, 0.0]]])
+    target = jnp.array([[[1.0, 2.0]]])
+
+    value = loss_fn(pred, target)
+
+    gaussian = 0.5 * (4.0 - jnp.log(4.0))
+    huber = 0.5
+    expected = gaussian + 0.25 * huber
+    assert jnp.allclose(value, expected)
+
+
+def test_build_loss_from_config_rejects_missing_tensor_key():
+    cfg = {"kind": "mse", "mask_key": "missing"}
+    with pytest.raises(ValueError, match="mask key 'missing' not found"):
+        build_loss_from_config(cfg, tensors={})
+
+
+def test_build_loss_from_user_config_absent_objective_returns_none():
+    cfg = {"pipeline": {"name": "calc_gradient"}}
+    assert build_loss_from_user_config(cfg) is None
+
+
+def test_build_loss_from_user_config_resolves_objective():
+    cfg = {
+        "inference": {
+            "objective": {
+                "kind": "huber",
+                "delta": 0.5,
+                "normalize": False,
+            }
+        }
+    }
+    loss_fn = build_loss_from_user_config(cfg)
+    assert loss_fn is not None
+
+    pred = jnp.array([[[3.0]]])
+    target = jnp.array([[[1.0]]])
+    value = loss_fn(pred, target)
+    # delta=0.5, |r|=2 => 0.5*(2*delta - delta^2)=delta*(|r|-delta/2)=0.875
+    assert jnp.allclose(value, 0.875)

--- a/tests/test_inference_performance_guardrails.py
+++ b/tests/test_inference_performance_guardrails.py
@@ -1,0 +1,84 @@
+from rubix.inference.benchmark import IFUCubeBenchmarkResult
+from rubix.inference.performance_guardrails import (
+    ObjectiveThresholds,
+    RuntimeThresholds,
+    check_ifu_optimization_guardrails,
+    check_vi_guardrails,
+)
+from rubix.inference.vi_benchmark import VIBenchmarkResult
+
+
+def _make_opt_result(mean_runtime=1.0, final_loss=1e-4, best_loss=1e-4):
+    return IFUCubeBenchmarkResult(
+        repeats=3,
+        warmup=True,
+        runtimes_s=[mean_runtime, mean_runtime, mean_runtime],
+        mean_runtime_s=mean_runtime,
+        median_runtime_s=mean_runtime,
+        min_runtime_s=mean_runtime,
+        max_runtime_s=mean_runtime,
+        steps_run=10,
+        final_loss=final_loss,
+        best_loss=best_loss,
+        target_nbytes=1024,
+        mask_nbytes=0,
+        weights_nbytes=0,
+        estimated_objective_working_set_nbytes=4096,
+    )
+
+
+def _make_vi_result(mean_runtime=1.0, final_obj=1e-3, best_obj=8e-4):
+    return VIBenchmarkResult(
+        repeats=3,
+        warmup=True,
+        runtimes_s=[mean_runtime, mean_runtime, mean_runtime],
+        mean_runtime_s=mean_runtime,
+        median_runtime_s=mean_runtime,
+        min_runtime_s=mean_runtime,
+        max_runtime_s=mean_runtime,
+        steps_run=12,
+        final_objective=final_obj,
+        best_objective=best_obj,
+        final_reconstruction=final_obj,
+        final_kl=1e-5,
+        target_nbytes=1024,
+    )
+
+
+def test_check_ifu_optimization_guardrails_passes_within_limits():
+    result = _make_opt_result()
+    runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+    objective = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+
+    check = check_ifu_optimization_guardrails(result, runtime, objective)
+    assert check.passed is True
+
+
+def test_check_ifu_optimization_guardrails_fails_on_runtime_and_loss():
+    result = _make_opt_result(mean_runtime=3.0, final_loss=1e-1, best_loss=1e-2)
+    runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+    objective = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+
+    check = check_ifu_optimization_guardrails(result, runtime, objective)
+    assert check.passed is False
+    assert "mean runtime" in check.message
+    assert "final loss" in check.message
+
+
+def test_check_vi_guardrails_passes_within_limits():
+    result = _make_vi_result()
+    runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+    objective = ObjectiveThresholds(max_final_objective=2e-3, max_best_objective=2e-3)
+
+    check = check_vi_guardrails(result, runtime, objective)
+    assert check.passed is True
+
+
+def test_check_vi_guardrails_fails_on_objective():
+    result = _make_vi_result(final_obj=5e-2, best_obj=4e-2)
+    runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+    objective = ObjectiveThresholds(max_final_objective=1e-3, max_best_objective=1e-3)
+
+    check = check_vi_guardrails(result, runtime, objective)
+    assert check.passed is False
+    assert "final objective" in check.message

--- a/tests/test_inference_performance_guardrails.py
+++ b/tests/test_inference_performance_guardrails.py
@@ -1,7 +1,8 @@
 from rubix.inference.benchmark import IFUCubeBenchmarkResult
 from rubix.inference.performance_guardrails import (
-    ObjectiveThresholds,
+    OptimizationObjectiveThresholds,
     RuntimeThresholds,
+    VIObjectiveThresholds,
     check_ifu_optimization_guardrails,
     check_vi_guardrails,
 )
@@ -48,7 +49,7 @@ def _make_vi_result(mean_runtime=1.0, final_obj=1e-3, best_obj=8e-4):
 def test_check_ifu_optimization_guardrails_passes_within_limits():
     result = _make_opt_result()
     runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-    objective = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+    objective = OptimizationObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
 
     check = check_ifu_optimization_guardrails(result, runtime, objective)
     assert check.passed is True
@@ -57,7 +58,7 @@ def test_check_ifu_optimization_guardrails_passes_within_limits():
 def test_check_ifu_optimization_guardrails_fails_on_runtime_and_loss():
     result = _make_opt_result(mean_runtime=3.0, final_loss=1e-1, best_loss=1e-2)
     runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-    objective = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+    objective = OptimizationObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
 
     check = check_ifu_optimization_guardrails(result, runtime, objective)
     assert check.passed is False
@@ -68,7 +69,7 @@ def test_check_ifu_optimization_guardrails_fails_on_runtime_and_loss():
 def test_check_vi_guardrails_passes_within_limits():
     result = _make_vi_result()
     runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-    objective = ObjectiveThresholds(max_final_objective=2e-3, max_best_objective=2e-3)
+    objective = VIObjectiveThresholds(max_final_objective=2e-3, max_best_objective=2e-3)
 
     check = check_vi_guardrails(result, runtime, objective)
     assert check.passed is True
@@ -77,7 +78,7 @@ def test_check_vi_guardrails_passes_within_limits():
 def test_check_vi_guardrails_fails_on_objective():
     result = _make_vi_result(final_obj=5e-2, best_obj=4e-2)
     runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-    objective = ObjectiveThresholds(max_final_objective=1e-3, max_best_objective=1e-3)
+    objective = VIObjectiveThresholds(max_final_objective=1e-3, max_best_objective=1e-3)
 
     check = check_vi_guardrails(result, runtime, objective)
     assert check.passed is False

--- a/tests/test_inference_posterior_predictive.py
+++ b/tests/test_inference_posterior_predictive.py
@@ -1,0 +1,100 @@
+import jax.numpy as jnp
+import pytest
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import (
+    compute_residual_products,
+    sample_posterior_predictive_cubes,
+    summarize_masked_metrics,
+    summarize_predictive_cube_samples,
+)
+
+
+class CubeScalePipeline:
+    """Pipeline that scales a fixed cube template by stars.age[0]."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([1.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_sample_posterior_predictive_cubes_shape():
+    pipeline = CubeScalePipeline(jnp.ones((2, 2, 3), dtype=jnp.float32))
+    static_data = _make_rubix_data()
+    mean = {"stars": {"age": jnp.array([1.5])}}
+    log_std = {"stars": {"age": jnp.array([-3.0])}}
+
+    samples = sample_posterior_predictive_cubes(
+        pipeline=pipeline,
+        posterior_mean_params=mean,
+        posterior_log_std_params=log_std,
+        static_data=static_data,
+        num_samples=5,
+        seed=7,
+    )
+
+    assert samples.shape == (5, 2, 2, 3)
+
+
+def test_summarize_predictive_cube_samples_outputs_expected_keys():
+    samples = jnp.arange(24, dtype=jnp.float32).reshape(3, 2, 2, 2)
+    summary = summarize_predictive_cube_samples(samples)
+
+    assert set(summary.keys()) == {"mean", "std", "p16", "p50", "p84"}
+    assert summary["mean"].shape == (2, 2, 2)
+
+
+def test_compute_residual_products_with_sigma_and_mask():
+    prediction = jnp.array([[[2.0, 1.0]]])
+    target = jnp.array([[[1.0, 2.0]]])
+    sigma = jnp.array([[[0.5, 1.0]]])
+    mask = jnp.array([[[1.0, 0.0]]])
+
+    products = compute_residual_products(
+        prediction=prediction,
+        target=target,
+        sigma=sigma,
+        mask=mask,
+    )
+
+    assert set(products.keys()) == {
+        "residual",
+        "abs_residual",
+        "chi2",
+        "masked_residual",
+        "masked_chi2",
+    }
+    assert jnp.allclose(products["chi2"], jnp.array([[[4.0, 1.0]]]))
+    assert jnp.allclose(products["masked_chi2"], jnp.array([[[4.0, 0.0]]]))
+
+
+def test_summarize_masked_metrics_matches_expected_values():
+    prediction = jnp.array([[[2.0, 0.0]]])
+    target = jnp.array([[[1.0, 2.0]]])
+    mask = jnp.array([[[1.0, 0.0]]])
+
+    metrics = summarize_masked_metrics(prediction, target, mask=mask)
+
+    assert pytest.approx(metrics["mse"]) == 1.0
+    assert pytest.approx(metrics["mae"]) == 1.0

--- a/tests/test_inference_workflows.py
+++ b/tests/test_inference_workflows.py
@@ -1,0 +1,65 @@
+import json
+
+import numpy as np
+
+from rubix.inference.workflows import (
+    run_synthetic_science_recipe,
+    save_science_recipe_outputs,
+)
+
+
+def test_run_synthetic_science_recipe_returns_expected_structure():
+    outputs = run_synthetic_science_recipe(
+        cube_shape=(2, 2, 4),
+        target_scale=1.5,
+        optimize_steps=20,
+        vi_steps=20,
+        num_vi_samples=2,
+        num_posterior_draws=4,
+        seed=0,
+    )
+
+    assert "config" in outputs
+    assert "optimization" in outputs
+    assert "variational" in outputs
+    assert "predictive_summary" in outputs
+    assert "residual_products" in outputs
+    assert "metrics" in outputs
+
+    assert outputs["predictive_summary"]["mean"].shape == (2, 2, 4)
+    assert outputs["residual_products"]["residual"].shape == (2, 2, 4)
+    assert outputs["metrics"]["mse"] >= 0.0
+    assert outputs["metrics"]["mae"] >= 0.0
+
+
+def test_save_science_recipe_outputs_writes_json_and_npz(tmp_path):
+    outputs = run_synthetic_science_recipe(
+        cube_shape=(2, 2, 4),
+        target_scale=1.2,
+        optimize_steps=10,
+        vi_steps=10,
+        num_vi_samples=2,
+        num_posterior_draws=3,
+        seed=1,
+    )
+
+    save_science_recipe_outputs(outputs, str(tmp_path))
+
+    summary_path = tmp_path / "summary.json"
+    predictive_path = tmp_path / "predictive_summary.npz"
+    residual_path = tmp_path / "residual_products.npz"
+
+    assert summary_path.exists()
+    assert predictive_path.exists()
+    assert residual_path.exists()
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["config"]["cube_shape"] == [2, 2, 4]
+    assert "final_loss" in summary["optimization"]
+    assert "final_objective" in summary["variational"]
+
+    predictive = np.load(predictive_path)
+    residual = np.load(residual_path)
+
+    assert predictive["mean"].shape == (2, 2, 4)
+    assert residual["residual"].shape == (2, 2, 4)


### PR DESCRIPTION
## Summary
- add rubix.inference.objective_config with config-driven loss builders
- support mse, gaussian_nll, huber, and weighted combined objectives
- support runtime tensor-key resolution for mask/weights/sigma/inverse-variance
- add helper to resolve objective config from user_config['inference']['objective']
- add unit tests for single, combined, and invalid configurations
- document objective-config usage in inference workflow docs

## Validation
- pre-commit passed on changed files
- compileall passed for module and tests