### PR TITLE
feat(inference): add posterior predictive and science output utilities

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -304,6 +304,22 @@ For large particle counts, configure optional IFU accumulation controls:
 
 These settings are used by the particlewise IFU builders in ``rubix.core.ifu``.
 
+
+Synthetic Science Recipe
+------------------------
+
+Run an end-to-end synthetic workflow (optimize -> VI -> posterior predictive ->
+residual metrics) and persist science-ready outputs:
+
+.. code-block:: bash
+
+   python scripts/run_synthetic_science_recipe.py \
+     --output-dir outputs/science_recipe \
+     --nx 8 --ny 8 --nw 64 \
+     --optimize-steps 200 \
+     --vi-steps 200 \
+     --num-posterior-draws 16
+
 Benchmarking Full-IFU Optimization
 ----------------------------------
 

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -282,13 +282,13 @@ thresholds in benchmark runs.
 .. code-block:: python
 
    from rubix.inference import (
-       ObjectiveThresholds,
+       OptimizationObjectiveThresholds,
        RuntimeThresholds,
        check_ifu_optimization_guardrails,
    )
 
    runtime_limits = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-   objective_limits = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+   objective_limits = OptimizationObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
    check = check_ifu_optimization_guardrails(bench_result, runtime_limits, objective_limits)
    assert check.passed, check.message
 

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -273,6 +273,26 @@ Generate posterior predictive cubes and science-ready residual summaries:
    metrics = summarize_masked_metrics(summary["mean"], target_cube, mask=valid_voxel_mask)
 
 
+Performance Guardrails
+----------------------
+
+Use guardrails to fail fast when runtime/objective regressions exceed expected
+thresholds in benchmark runs.
+
+.. code-block:: python
+
+   from rubix.inference import (
+       ObjectiveThresholds,
+       RuntimeThresholds,
+       check_ifu_optimization_guardrails,
+   )
+
+   runtime_limits = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+   objective_limits = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+   check = check_ifu_optimization_guardrails(bench_result, runtime_limits, objective_limits)
+   assert check.passed, check.message
+
+
 Performance Notes
 -----------------
 

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -247,6 +247,32 @@ Both optimization and VI now support resumable state plus checkpoint helpers.
    )
 
 
+Posterior Predictive Outputs
+----------------------------
+
+Generate posterior predictive cubes and science-ready residual summaries:
+
+.. code-block:: python
+
+   from rubix.inference import (
+       compute_residual_products,
+       sample_posterior_predictive_cubes,
+       summarize_masked_metrics,
+       summarize_predictive_cube_samples,
+   )
+
+   samples = sample_posterior_predictive_cubes(
+       pipeline=pipe_det,
+       posterior_mean_params=vi.posterior_mean_params,
+       posterior_log_std_params=vi.posterior_log_std_params,
+       static_data=static_data,
+       num_samples=16,
+   )
+   summary = summarize_predictive_cube_samples(samples)
+   residual_maps = compute_residual_products(summary["mean"], target_cube)
+   metrics = summarize_masked_metrics(summary["mean"], target_cube, mask=valid_voxel_mask)
+
+
 Performance Notes
 -----------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -84,6 +84,14 @@ rubix.inference.parameterization module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.performance_guardrails module
+---------------------------------------------
+
+.. automodule:: rubix.inference.performance_guardrails
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.validation module
 ---------------------------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -116,6 +116,14 @@ rubix.inference.vi_benchmark module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.workflows module
+--------------------------------
+
+.. automodule:: rubix.inference.workflows
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -52,6 +52,14 @@ rubix.inference.optimize module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.posterior_predictive module
+-------------------------------------------
+
+.. automodule:: rubix.inference.posterior_predictive
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.objective_config module
 ---------------------------------------
 

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -63,6 +63,7 @@ from .vi_benchmark import (
     benchmark_variational_inference,
     vi_benchmark_result_to_dict,
 )
+from .workflows import run_synthetic_science_recipe, save_science_recipe_outputs
 
 __all__ = [
     "IdentityTransform",
@@ -122,4 +123,6 @@ __all__ = [
     "summarize_predictive_cube_samples",
     "save_checkpoint",
     "value_and_grad",
+    "run_synthetic_science_recipe",
+    "save_science_recipe_outputs",
 ]

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -36,9 +36,10 @@ from .parameterization import (
     inverse_transforms,
 )
 from .performance_guardrails import (
-    ObjectiveThresholds,
+    OptimizationObjectiveThresholds,
     PerformanceCheckResult,
     RuntimeThresholds,
+    VIObjectiveThresholds,
     check_ifu_optimization_guardrails,
     check_vi_guardrails,
 )
@@ -74,9 +75,10 @@ __all__ = [
     "IFUCubeBenchmarkResult",
     "OptimizationResult",
     "OptimizationState",
-    "ObjectiveThresholds",
+    "OptimizationObjectiveThresholds",
     "PerformanceCheckResult",
     "RuntimeThresholds",
+    "VIObjectiveThresholds",
     "VariationalResult",
     "VariationalState",
     "VIBenchmarkResult",

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -35,6 +35,12 @@ from .parameterization import (
     build_age_metallicity_transforms,
     inverse_transforms,
 )
+from .posterior_predictive import (
+    compute_residual_products,
+    sample_posterior_predictive_cubes,
+    summarize_masked_metrics,
+    summarize_predictive_cube_samples,
+)
 from .validation import GradientComparison, compare_gradients, finite_difference_grad
 from .variational import (
     VariationalResult,
@@ -77,6 +83,7 @@ __all__ = [
     "benchmark_ifu_cube_optimization",
     "benchmark_result_to_dict",
     "compare_gradients",
+    "compute_residual_products",
     "estimate_array_nbytes",
     "finite_difference_grad",
     "forward",
@@ -97,7 +104,10 @@ __all__ = [
     "optimize_params",
     "resume_optimization_from_checkpoint",
     "resume_variational_from_checkpoint",
+    "sample_posterior_predictive_cubes",
     "sample_diag_gaussian",
+    "summarize_masked_metrics",
+    "summarize_predictive_cube_samples",
     "save_checkpoint",
     "value_and_grad",
 ]

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -35,6 +35,13 @@ from .parameterization import (
     build_age_metallicity_transforms,
     inverse_transforms,
 )
+from .performance_guardrails import (
+    ObjectiveThresholds,
+    PerformanceCheckResult,
+    RuntimeThresholds,
+    check_ifu_optimization_guardrails,
+    check_vi_guardrails,
+)
 from .posterior_predictive import (
     compute_residual_products,
     sample_posterior_predictive_cubes,
@@ -66,6 +73,9 @@ __all__ = [
     "IFUCubeBenchmarkResult",
     "OptimizationResult",
     "OptimizationState",
+    "ObjectiveThresholds",
+    "PerformanceCheckResult",
+    "RuntimeThresholds",
     "VariationalResult",
     "VariationalState",
     "VIBenchmarkResult",
@@ -84,6 +94,8 @@ __all__ = [
     "benchmark_result_to_dict",
     "compare_gradients",
     "compute_residual_products",
+    "check_ifu_optimization_guardrails",
+    "check_vi_guardrails",
     "estimate_array_nbytes",
     "finite_difference_grad",
     "forward",

--- a/rubix/inference/performance_guardrails.py
+++ b/rubix/inference/performance_guardrails.py
@@ -1,0 +1,148 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from .benchmark import IFUCubeBenchmarkResult
+from .vi_benchmark import VIBenchmarkResult
+
+
+@dataclass(frozen=True)
+class RuntimeThresholds:
+    """Thresholds for runtime regression checks."""
+
+    max_mean_runtime_s: Optional[float] = None
+    max_median_runtime_s: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class ObjectiveThresholds:
+    """Thresholds for objective quality checks."""
+
+    max_final_loss: Optional[float] = None
+    max_best_loss: Optional[float] = None
+    max_final_objective: Optional[float] = None
+    max_best_objective: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class PerformanceCheckResult:
+    """Outcome of a performance guardrail check."""
+
+    passed: bool
+    message: str
+
+
+def _check_runtime(
+    mean_runtime_s: float,
+    median_runtime_s: float,
+    runtime_thresholds: RuntimeThresholds,
+) -> list[str]:
+    errors: list[str] = []
+    if runtime_thresholds.max_mean_runtime_s is not None:
+        if mean_runtime_s > runtime_thresholds.max_mean_runtime_s:
+            errors.append(
+                f"mean runtime {mean_runtime_s:.6f}s exceeds "
+                f"threshold {runtime_thresholds.max_mean_runtime_s:.6f}s"
+            )
+
+    if runtime_thresholds.max_median_runtime_s is not None:
+        if median_runtime_s > runtime_thresholds.max_median_runtime_s:
+            errors.append(
+                f"median runtime {median_runtime_s:.6f}s exceeds "
+                f"threshold {runtime_thresholds.max_median_runtime_s:.6f}s"
+            )
+
+    return errors
+
+
+def check_ifu_optimization_guardrails(
+    result: IFUCubeBenchmarkResult,
+    runtime_thresholds: RuntimeThresholds,
+    objective_thresholds: ObjectiveThresholds,
+) -> PerformanceCheckResult:
+    """Check optimization benchmark result against runtime/objective thresholds.
+
+    Args:
+        result (IFUCubeBenchmarkResult): Optimization benchmark result.
+        runtime_thresholds (RuntimeThresholds): Runtime limits.
+        objective_thresholds (ObjectiveThresholds): Objective/loss limits.
+
+    Returns:
+        PerformanceCheckResult: Pass/fail status and explanatory message.
+    """
+    errors = _check_runtime(
+        result.mean_runtime_s,
+        result.median_runtime_s,
+        runtime_thresholds,
+    )
+
+    if objective_thresholds.max_final_loss is not None:
+        if result.final_loss > objective_thresholds.max_final_loss:
+            errors.append(
+                f"final loss {result.final_loss:.6e} exceeds "
+                f"threshold {objective_thresholds.max_final_loss:.6e}"
+            )
+
+    if objective_thresholds.max_best_loss is not None:
+        if result.best_loss > objective_thresholds.max_best_loss:
+            errors.append(
+                f"best loss {result.best_loss:.6e} exceeds "
+                f"threshold {objective_thresholds.max_best_loss:.6e}"
+            )
+
+    if errors:
+        return PerformanceCheckResult(
+            passed=False,
+            message="; ".join(errors),
+        )
+
+    return PerformanceCheckResult(
+        passed=True,
+        message="optimization benchmark satisfies configured thresholds",
+    )
+
+
+def check_vi_guardrails(
+    result: VIBenchmarkResult,
+    runtime_thresholds: RuntimeThresholds,
+    objective_thresholds: ObjectiveThresholds,
+) -> PerformanceCheckResult:
+    """Check VI benchmark result against runtime/objective thresholds.
+
+    Args:
+        result (VIBenchmarkResult): VI benchmark result.
+        runtime_thresholds (RuntimeThresholds): Runtime limits.
+        objective_thresholds (ObjectiveThresholds): Objective limits.
+
+    Returns:
+        PerformanceCheckResult: Pass/fail status and explanatory message.
+    """
+    errors = _check_runtime(
+        result.mean_runtime_s,
+        result.median_runtime_s,
+        runtime_thresholds,
+    )
+
+    if objective_thresholds.max_final_objective is not None:
+        if result.final_objective > objective_thresholds.max_final_objective:
+            errors.append(
+                f"final objective {result.final_objective:.6e} exceeds "
+                f"threshold {objective_thresholds.max_final_objective:.6e}"
+            )
+
+    if objective_thresholds.max_best_objective is not None:
+        if result.best_objective > objective_thresholds.max_best_objective:
+            errors.append(
+                f"best objective {result.best_objective:.6e} exceeds "
+                f"threshold {objective_thresholds.max_best_objective:.6e}"
+            )
+
+    if errors:
+        return PerformanceCheckResult(
+            passed=False,
+            message="; ".join(errors),
+        )
+
+    return PerformanceCheckResult(
+        passed=True,
+        message="VI benchmark satisfies configured thresholds",
+    )

--- a/rubix/inference/performance_guardrails.py
+++ b/rubix/inference/performance_guardrails.py
@@ -14,11 +14,17 @@ class RuntimeThresholds:
 
 
 @dataclass(frozen=True)
-class ObjectiveThresholds:
-    """Thresholds for objective quality checks."""
+class OptimizationObjectiveThresholds:
+    """Thresholds for optimization loss quality checks."""
 
     max_final_loss: Optional[float] = None
     max_best_loss: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class VIObjectiveThresholds:
+    """Thresholds for variational inference objective quality checks."""
+
     max_final_objective: Optional[float] = None
     max_best_objective: Optional[float] = None
 
@@ -57,14 +63,14 @@ def _check_runtime(
 def check_ifu_optimization_guardrails(
     result: IFUCubeBenchmarkResult,
     runtime_thresholds: RuntimeThresholds,
-    objective_thresholds: ObjectiveThresholds,
+    objective_thresholds: OptimizationObjectiveThresholds,
 ) -> PerformanceCheckResult:
     """Check optimization benchmark result against runtime/objective thresholds.
 
     Args:
         result (IFUCubeBenchmarkResult): Optimization benchmark result.
         runtime_thresholds (RuntimeThresholds): Runtime limits.
-        objective_thresholds (ObjectiveThresholds): Objective/loss limits.
+        objective_thresholds (OptimizationObjectiveThresholds): Loss limits.
 
     Returns:
         PerformanceCheckResult: Pass/fail status and explanatory message.
@@ -104,14 +110,14 @@ def check_ifu_optimization_guardrails(
 def check_vi_guardrails(
     result: VIBenchmarkResult,
     runtime_thresholds: RuntimeThresholds,
-    objective_thresholds: ObjectiveThresholds,
+    objective_thresholds: VIObjectiveThresholds,
 ) -> PerformanceCheckResult:
     """Check VI benchmark result against runtime/objective thresholds.
 
     Args:
         result (VIBenchmarkResult): VI benchmark result.
         runtime_thresholds (RuntimeThresholds): Runtime limits.
-        objective_thresholds (ObjectiveThresholds): Objective limits.
+        objective_thresholds (VIObjectiveThresholds): Objective limits.
 
     Returns:
         PerformanceCheckResult: Pass/fail status and explanatory message.

--- a/rubix/inference/posterior_predictive.py
+++ b/rubix/inference/posterior_predictive.py
@@ -50,8 +50,7 @@ def sample_posterior_predictive_cubes(
     base_key = jax.random.PRNGKey(seed)
     sample_keys = jax.random.split(base_key, num_samples)
 
-    cubes = []
-    for key in sample_keys:
+    def _single_sample(key):
         sampled_unconstrained = sample_diag_gaussian(
             mean=posterior_mean_params,
             log_std=posterior_log_std_params,
@@ -65,16 +64,14 @@ def sample_posterior_predictive_cubes(
                 transforms=transforms,
                 direction="forward",
             )
-        cubes.append(
-            forward(
-                pipeline=pipeline,
-                params=sampled_constrained,
-                static_data=static_data,
-                noise_key=noise_key,
-            )
+        return forward(
+            pipeline=pipeline,
+            params=sampled_constrained,
+            static_data=static_data,
+            noise_key=noise_key,
         )
 
-    return jnp.stack(cubes, axis=0)
+    return jax.lax.map(_single_sample, sample_keys)
 
 
 def summarize_predictive_cube_samples(samples: jnp.ndarray) -> dict[str, jnp.ndarray]:

--- a/rubix/inference/posterior_predictive.py
+++ b/rubix/inference/posterior_predictive.py
@@ -1,0 +1,212 @@
+from typing import Any, Mapping, Optional
+
+import jax
+import jax.numpy as jnp
+
+from rubix.core.data import RubixData
+
+from .api import LossFn, forward
+from .parameterization import TransformTree, apply_transforms
+from .variational import sample_diag_gaussian
+
+ParamsTree = Mapping[str, Mapping[str, Any]]
+
+
+def sample_posterior_predictive_cubes(
+    pipeline: Any,
+    posterior_mean_params: ParamsTree,
+    posterior_log_std_params: ParamsTree,
+    static_data: RubixData,
+    num_samples: int,
+    transforms: Optional[TransformTree] = None,
+    noise_key: Optional[jnp.ndarray] = None,
+    seed: int = 0,
+) -> jnp.ndarray:
+    """Draw posterior predictive cubes from a diagonal Gaussian posterior.
+
+    Args:
+        pipeline (Any): Pipeline-like object exposing ``run_sharded``.
+        posterior_mean_params (ParamsTree): Mean parameters in unconstrained
+            space.
+        posterior_log_std_params (ParamsTree): Log-std parameters in
+            unconstrained space.
+        static_data (RubixData): Baseline model data.
+        num_samples (int): Number of posterior predictive draws.
+        transforms (Optional[TransformTree], optional): Optional transform tree
+            to constrained space. Defaults to ``None``.
+        noise_key (Optional[jnp.ndarray], optional): Optional noise key passed
+            to each forward pass. Defaults to ``None``.
+        seed (int, optional): Random seed. Defaults to 0.
+
+    Raises:
+        ValueError: If ``num_samples`` is not strictly positive.
+
+    Returns:
+        jnp.ndarray: Predictive samples stacked as ``(num_samples, *cube_shape)``.
+    """
+    if num_samples <= 0:
+        raise ValueError("num_samples must be strictly positive")
+
+    base_key = jax.random.PRNGKey(seed)
+    sample_keys = jax.random.split(base_key, num_samples)
+
+    cubes = []
+    for key in sample_keys:
+        sampled_unconstrained = sample_diag_gaussian(
+            mean=posterior_mean_params,
+            log_std=posterior_log_std_params,
+            key=key,
+        )
+        if transforms is None:
+            sampled_constrained = sampled_unconstrained
+        else:
+            sampled_constrained = apply_transforms(
+                params=sampled_unconstrained,
+                transforms=transforms,
+                direction="forward",
+            )
+        cubes.append(
+            forward(
+                pipeline=pipeline,
+                params=sampled_constrained,
+                static_data=static_data,
+                noise_key=noise_key,
+            )
+        )
+
+    return jnp.stack(cubes, axis=0)
+
+
+def summarize_predictive_cube_samples(samples: jnp.ndarray) -> dict[str, jnp.ndarray]:
+    """Summarize predictive cube samples via moments and quantiles.
+
+    Args:
+        samples (jnp.ndarray): Predictive cubes with leading sample axis.
+
+    Raises:
+        ValueError: If ``samples`` does not include a sample axis.
+
+    Returns:
+        dict[str, jnp.ndarray]: Summary maps with keys ``mean``, ``std``,
+        ``p16``, ``p50``, and ``p84``.
+    """
+    if samples.ndim < 2:
+        raise ValueError("samples must include a leading sample axis")
+
+    return {
+        "mean": jnp.mean(samples, axis=0),
+        "std": jnp.std(samples, axis=0),
+        "p16": jnp.percentile(samples, 16.0, axis=0),
+        "p50": jnp.percentile(samples, 50.0, axis=0),
+        "p84": jnp.percentile(samples, 84.0, axis=0),
+    }
+
+
+def compute_residual_products(
+    prediction: jnp.ndarray,
+    target: jnp.ndarray,
+    sigma: Optional[jnp.ndarray] = None,
+    inv_variance: Optional[jnp.ndarray] = None,
+    mask: Optional[jnp.ndarray] = None,
+) -> dict[str, jnp.ndarray]:
+    """Compute residual, absolute residual, and chi2-like products.
+
+    Args:
+        prediction (jnp.ndarray): Predicted IFU cube.
+        target (jnp.ndarray): Target IFU cube with matching shape.
+        sigma (Optional[jnp.ndarray], optional): Per-voxel sigma cube.
+            Defaults to ``None``.
+        inv_variance (Optional[jnp.ndarray], optional): Per-voxel inverse
+            variance cube. Defaults to ``None``.
+        mask (Optional[jnp.ndarray], optional): Optional binary mask.
+            Defaults to ``None``.
+
+    Raises:
+        ValueError: If shapes are inconsistent or both ``sigma`` and
+            ``inv_variance`` are provided.
+
+    Returns:
+        dict[str, jnp.ndarray]: Residual-derived maps.
+    """
+    if prediction.shape != target.shape:
+        raise ValueError("prediction and target must have the same shape")
+
+    if sigma is not None and sigma.shape != target.shape:
+        raise ValueError("sigma must have the same shape as target")
+
+    if inv_variance is not None and inv_variance.shape != target.shape:
+        raise ValueError("inv_variance must have the same shape as target")
+
+    if mask is not None and mask.shape != target.shape:
+        raise ValueError("mask must have the same shape as target")
+
+    if sigma is not None and inv_variance is not None:
+        raise ValueError("provide only one of sigma or inv_variance")
+
+    residual = prediction - target
+    abs_residual = jnp.abs(residual)
+
+    if inv_variance is not None:
+        chi2 = residual**2 * inv_variance
+    elif sigma is not None:
+        chi2 = residual**2 / jnp.maximum(sigma**2, jnp.asarray(1e-12, sigma.dtype))
+    else:
+        chi2 = residual**2
+
+    if mask is None:
+        mask_f = jnp.ones_like(residual)
+    else:
+        mask_f = mask.astype(residual.dtype)
+
+    return {
+        "residual": residual,
+        "abs_residual": abs_residual,
+        "chi2": chi2,
+        "masked_residual": residual * mask_f,
+        "masked_chi2": chi2 * mask_f,
+    }
+
+
+def summarize_masked_metrics(
+    prediction: jnp.ndarray,
+    target: jnp.ndarray,
+    mask: Optional[jnp.ndarray] = None,
+    loss_fn: Optional[LossFn] = None,
+) -> dict[str, float]:
+    """Compute scalar masked summary metrics for science reporting.
+
+    Args:
+        prediction (jnp.ndarray): Predicted IFU cube.
+        target (jnp.ndarray): Target IFU cube.
+        mask (Optional[jnp.ndarray], optional): Optional binary mask.
+            Defaults to ``None``.
+        loss_fn (Optional[LossFn], optional): Optional custom scalar loss.
+            Defaults to ``None``.
+
+    Raises:
+        ValueError: If prediction/target shapes (or mask shape) are invalid.
+
+    Returns:
+        dict[str, float]: Summary metrics including ``mse``, ``mae``, and
+        optionally ``custom_loss``.
+    """
+    if prediction.shape != target.shape:
+        raise ValueError("prediction and target must have the same shape")
+
+    if mask is not None and mask.shape != target.shape:
+        raise ValueError("mask must have the same shape as target")
+
+    residual = prediction - target
+    if mask is None:
+        mask_f = jnp.ones_like(residual)
+    else:
+        mask_f = mask.astype(residual.dtype)
+
+    denom = jnp.maximum(jnp.sum(mask_f), jnp.asarray(1e-12, dtype=residual.dtype))
+    mse = jnp.sum((residual**2) * mask_f) / denom
+    mae = jnp.sum(jnp.abs(residual) * mask_f) / denom
+
+    metrics = {"mse": float(mse), "mae": float(mae)}
+    if loss_fn is not None:
+        metrics["custom_loss"] = float(loss_fn(prediction, target))
+    return metrics

--- a/rubix/inference/posterior_predictive.py
+++ b/rubix/inference/posterior_predictive.py
@@ -147,9 +147,11 @@ def compute_residual_products(
     abs_residual = jnp.abs(residual)
 
     if inv_variance is not None:
-        chi2 = residual**2 * inv_variance
+        chi2 = residual**2 * inv_variance.astype(residual.dtype)
     elif sigma is not None:
-        chi2 = residual**2 / jnp.maximum(sigma**2, jnp.asarray(1e-12, sigma.dtype))
+        eps_arr = jnp.asarray(1e-12, dtype=residual.dtype)
+        sigma_safe = jnp.maximum(sigma.astype(residual.dtype), eps_arr)
+        chi2 = residual**2 / (sigma_safe**2)
     else:
         chi2 = residual**2
 

--- a/rubix/inference/workflows.py
+++ b/rubix/inference/workflows.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jax.numpy as jnp
+import numpy as np
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+
+from .optimize import optimize_ifu_cube
+from .posterior_predictive import (
+    compute_residual_products,
+    sample_posterior_predictive_cubes,
+    summarize_masked_metrics,
+    summarize_predictive_cube_samples,
+)
+from .variational import optimize_variational_ifu_cube
+
+
+class SyntheticScalePipeline:
+    """Simple synthetic IFU pipeline used by the science recipe workflow."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _make_static_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([0.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Convert nested JAX/NumPy containers into JSON-serializable values."""
+    if isinstance(value, dict):
+        return {k: _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(v) for v in value]
+    if isinstance(value, np.ndarray):
+        if value.ndim == 0:
+            return value.item()
+        return value.tolist()
+    if isinstance(value, jnp.ndarray):
+        arr = np.asarray(value)
+        if arr.ndim == 0:
+            return arr.item()
+        return arr.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def run_synthetic_science_recipe(
+    cube_shape: tuple[int, int, int] = (4, 4, 16),
+    target_scale: float = 1.7,
+    optimize_steps: int = 120,
+    vi_steps: int = 120,
+    num_vi_samples: int = 4,
+    num_posterior_draws: int = 8,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Run a compact end-to-end synthetic science workflow.
+
+    This workflow performs deterministic optimization, variational inference,
+    posterior predictive sampling, and residual/metric summarization.
+
+    Args:
+        cube_shape (tuple[int, int, int], optional): Synthetic IFU cube shape
+            ``(nx, ny, nw)``. Defaults to ``(4, 4, 16)``.
+        target_scale (float, optional): Multiplicative scale for the synthetic
+            target cube. Defaults to 1.7.
+        optimize_steps (int, optional): Maximum deterministic optimization
+            steps. Defaults to 120.
+        vi_steps (int, optional): Maximum variational optimization steps.
+            Defaults to 120.
+        num_vi_samples (int, optional): Monte Carlo samples per VI step.
+            Defaults to 4.
+        num_posterior_draws (int, optional): Number of posterior predictive
+            cube draws. Defaults to 8.
+        seed (int, optional): Random seed for VI and predictive sampling.
+            Defaults to 0.
+
+    Returns:
+        dict[str, Any]: Workflow outputs and diagnostic summaries.
+    """
+    template = jnp.ones(cube_shape, dtype=jnp.float32)
+    target = target_scale * template
+
+    pipeline = SyntheticScalePipeline(template)
+    static_data = _make_static_data()
+    params_init = {"stars": {"age": jnp.array([0.2])}}
+
+    opt_result = optimize_ifu_cube(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        learning_rate=0.1,
+        max_steps=optimize_steps,
+        tol=1e-8,
+    )
+
+    vi_result = optimize_variational_ifu_cube(
+        pipeline=pipeline,
+        params_init=params_init,
+        static_data=static_data,
+        target=target,
+        sigma=jnp.ones_like(target),
+        learning_rate=5e-2,
+        max_steps=vi_steps,
+        tol=1e-8,
+        num_samples=num_vi_samples,
+        beta_kl=1e-4,
+        seed=seed,
+    )
+
+    predictive_samples = sample_posterior_predictive_cubes(
+        pipeline=pipeline,
+        posterior_mean_params=vi_result.posterior_mean_params,
+        posterior_log_std_params=vi_result.posterior_log_std_params,
+        static_data=static_data,
+        num_samples=num_posterior_draws,
+        seed=seed + 1,
+    )
+    predictive_summary = summarize_predictive_cube_samples(predictive_samples)
+    residual_products = compute_residual_products(
+        prediction=predictive_summary["mean"],
+        target=target,
+    )
+    metrics = summarize_masked_metrics(
+        prediction=predictive_summary["mean"],
+        target=target,
+    )
+
+    return {
+        "config": {
+            "cube_shape": cube_shape,
+            "target_scale": target_scale,
+            "optimize_steps": optimize_steps,
+            "vi_steps": vi_steps,
+            "num_vi_samples": num_vi_samples,
+            "num_posterior_draws": num_posterior_draws,
+            "seed": seed,
+        },
+        "optimization": {
+            "final_loss": opt_result.final_loss,
+            "best_loss": opt_result.best_loss,
+            "steps_run": opt_result.steps_run,
+            "converged": opt_result.converged,
+        },
+        "variational": {
+            "final_objective": vi_result.final_objective,
+            "best_objective": vi_result.best_objective,
+            "steps_run": vi_result.steps_run,
+            "converged": vi_result.converged,
+        },
+        "predictive_summary": predictive_summary,
+        "residual_products": residual_products,
+        "metrics": metrics,
+    }
+
+
+def save_science_recipe_outputs(
+    outputs: dict[str, Any],
+    output_dir: str,
+) -> None:
+    """Persist workflow outputs to JSON and NPZ files.
+
+    Args:
+        outputs (dict[str, Any]): Outputs from
+            :func:`run_synthetic_science_recipe`.
+        output_dir (str): Destination directory.
+    """
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = {
+        "config": outputs["config"],
+        "optimization": outputs["optimization"],
+        "variational": outputs["variational"],
+        "metrics": outputs["metrics"],
+    }
+    json_summary = _to_jsonable(summary)
+    (out_dir / "summary.json").write_text(
+        json.dumps(json_summary, indent=2), encoding="utf-8"
+    )
+
+    predictive_np = {k: np.asarray(v) for k, v in outputs["predictive_summary"].items()}
+    residual_np = {k: np.asarray(v) for k, v in outputs["residual_products"].items()}
+
+    np.savez(out_dir / "predictive_summary.npz", **predictive_np)
+    np.savez(out_dir / "residual_products.npz", **residual_np)

--- a/scripts/run_synthetic_science_recipe.py
+++ b/scripts/run_synthetic_science_recipe.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import argparse
+
+from rubix.inference.workflows import (
+    run_synthetic_science_recipe,
+    save_science_recipe_outputs,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run synthetic end-to-end science workflow and save outputs."
+    )
+    parser.add_argument("--output-dir", type=str, default="outputs/science_recipe")
+    parser.add_argument("--nx", type=int, default=4)
+    parser.add_argument("--ny", type=int, default=4)
+    parser.add_argument("--nw", type=int, default=16)
+    parser.add_argument("--target-scale", type=float, default=1.7)
+    parser.add_argument("--optimize-steps", type=int, default=120)
+    parser.add_argument("--vi-steps", type=int, default=120)
+    parser.add_argument("--num-vi-samples", type=int, default=4)
+    parser.add_argument("--num-posterior-draws", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    outputs = run_synthetic_science_recipe(
+        cube_shape=(args.nx, args.ny, args.nw),
+        target_scale=args.target_scale,
+        optimize_steps=args.optimize_steps,
+        vi_steps=args.vi_steps,
+        num_vi_samples=args.num_vi_samples,
+        num_posterior_draws=args.num_posterior_draws,
+        seed=args.seed,
+    )
+    save_science_recipe_outputs(outputs, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_inference_performance_guardrails.py
+++ b/tests/test_inference_performance_guardrails.py
@@ -1,0 +1,84 @@
+from rubix.inference.benchmark import IFUCubeBenchmarkResult
+from rubix.inference.performance_guardrails import (
+    ObjectiveThresholds,
+    RuntimeThresholds,
+    check_ifu_optimization_guardrails,
+    check_vi_guardrails,
+)
+from rubix.inference.vi_benchmark import VIBenchmarkResult
+
+
+def _make_opt_result(mean_runtime=1.0, final_loss=1e-4, best_loss=1e-4):
+    return IFUCubeBenchmarkResult(
+        repeats=3,
+        warmup=True,
+        runtimes_s=[mean_runtime, mean_runtime, mean_runtime],
+        mean_runtime_s=mean_runtime,
+        median_runtime_s=mean_runtime,
+        min_runtime_s=mean_runtime,
+        max_runtime_s=mean_runtime,
+        steps_run=10,
+        final_loss=final_loss,
+        best_loss=best_loss,
+        target_nbytes=1024,
+        mask_nbytes=0,
+        weights_nbytes=0,
+        estimated_objective_working_set_nbytes=4096,
+    )
+
+
+def _make_vi_result(mean_runtime=1.0, final_obj=1e-3, best_obj=8e-4):
+    return VIBenchmarkResult(
+        repeats=3,
+        warmup=True,
+        runtimes_s=[mean_runtime, mean_runtime, mean_runtime],
+        mean_runtime_s=mean_runtime,
+        median_runtime_s=mean_runtime,
+        min_runtime_s=mean_runtime,
+        max_runtime_s=mean_runtime,
+        steps_run=12,
+        final_objective=final_obj,
+        best_objective=best_obj,
+        final_reconstruction=final_obj,
+        final_kl=1e-5,
+        target_nbytes=1024,
+    )
+
+
+def test_check_ifu_optimization_guardrails_passes_within_limits():
+    result = _make_opt_result()
+    runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+    objective = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+
+    check = check_ifu_optimization_guardrails(result, runtime, objective)
+    assert check.passed is True
+
+
+def test_check_ifu_optimization_guardrails_fails_on_runtime_and_loss():
+    result = _make_opt_result(mean_runtime=3.0, final_loss=1e-1, best_loss=1e-2)
+    runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+    objective = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+
+    check = check_ifu_optimization_guardrails(result, runtime, objective)
+    assert check.passed is False
+    assert "mean runtime" in check.message
+    assert "final loss" in check.message
+
+
+def test_check_vi_guardrails_passes_within_limits():
+    result = _make_vi_result()
+    runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+    objective = ObjectiveThresholds(max_final_objective=2e-3, max_best_objective=2e-3)
+
+    check = check_vi_guardrails(result, runtime, objective)
+    assert check.passed is True
+
+
+def test_check_vi_guardrails_fails_on_objective():
+    result = _make_vi_result(final_obj=5e-2, best_obj=4e-2)
+    runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
+    objective = ObjectiveThresholds(max_final_objective=1e-3, max_best_objective=1e-3)
+
+    check = check_vi_guardrails(result, runtime, objective)
+    assert check.passed is False
+    assert "final objective" in check.message

--- a/tests/test_inference_performance_guardrails.py
+++ b/tests/test_inference_performance_guardrails.py
@@ -1,7 +1,8 @@
 from rubix.inference.benchmark import IFUCubeBenchmarkResult
 from rubix.inference.performance_guardrails import (
-    ObjectiveThresholds,
+    OptimizationObjectiveThresholds,
     RuntimeThresholds,
+    VIObjectiveThresholds,
     check_ifu_optimization_guardrails,
     check_vi_guardrails,
 )
@@ -48,7 +49,7 @@ def _make_vi_result(mean_runtime=1.0, final_obj=1e-3, best_obj=8e-4):
 def test_check_ifu_optimization_guardrails_passes_within_limits():
     result = _make_opt_result()
     runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-    objective = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+    objective = OptimizationObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
 
     check = check_ifu_optimization_guardrails(result, runtime, objective)
     assert check.passed is True
@@ -57,7 +58,7 @@ def test_check_ifu_optimization_guardrails_passes_within_limits():
 def test_check_ifu_optimization_guardrails_fails_on_runtime_and_loss():
     result = _make_opt_result(mean_runtime=3.0, final_loss=1e-1, best_loss=1e-2)
     runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-    objective = ObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
+    objective = OptimizationObjectiveThresholds(max_final_loss=1e-3, max_best_loss=1e-3)
 
     check = check_ifu_optimization_guardrails(result, runtime, objective)
     assert check.passed is False
@@ -68,7 +69,7 @@ def test_check_ifu_optimization_guardrails_fails_on_runtime_and_loss():
 def test_check_vi_guardrails_passes_within_limits():
     result = _make_vi_result()
     runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-    objective = ObjectiveThresholds(max_final_objective=2e-3, max_best_objective=2e-3)
+    objective = VIObjectiveThresholds(max_final_objective=2e-3, max_best_objective=2e-3)
 
     check = check_vi_guardrails(result, runtime, objective)
     assert check.passed is True
@@ -77,7 +78,7 @@ def test_check_vi_guardrails_passes_within_limits():
 def test_check_vi_guardrails_fails_on_objective():
     result = _make_vi_result(final_obj=5e-2, best_obj=4e-2)
     runtime = RuntimeThresholds(max_mean_runtime_s=2.0, max_median_runtime_s=2.0)
-    objective = ObjectiveThresholds(max_final_objective=1e-3, max_best_objective=1e-3)
+    objective = VIObjectiveThresholds(max_final_objective=1e-3, max_best_objective=1e-3)
 
     check = check_vi_guardrails(result, runtime, objective)
     assert check.passed is False

--- a/tests/test_inference_posterior_predictive.py
+++ b/tests/test_inference_posterior_predictive.py
@@ -1,0 +1,100 @@
+import jax.numpy as jnp
+import pytest
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import (
+    compute_residual_products,
+    sample_posterior_predictive_cubes,
+    summarize_masked_metrics,
+    summarize_predictive_cube_samples,
+)
+
+
+class CubeScalePipeline:
+    """Pipeline that scales a fixed cube template by stars.age[0]."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _make_rubix_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([1.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def test_sample_posterior_predictive_cubes_shape():
+    pipeline = CubeScalePipeline(jnp.ones((2, 2, 3), dtype=jnp.float32))
+    static_data = _make_rubix_data()
+    mean = {"stars": {"age": jnp.array([1.5])}}
+    log_std = {"stars": {"age": jnp.array([-3.0])}}
+
+    samples = sample_posterior_predictive_cubes(
+        pipeline=pipeline,
+        posterior_mean_params=mean,
+        posterior_log_std_params=log_std,
+        static_data=static_data,
+        num_samples=5,
+        seed=7,
+    )
+
+    assert samples.shape == (5, 2, 2, 3)
+
+
+def test_summarize_predictive_cube_samples_outputs_expected_keys():
+    samples = jnp.arange(24, dtype=jnp.float32).reshape(3, 2, 2, 2)
+    summary = summarize_predictive_cube_samples(samples)
+
+    assert set(summary.keys()) == {"mean", "std", "p16", "p50", "p84"}
+    assert summary["mean"].shape == (2, 2, 2)
+
+
+def test_compute_residual_products_with_sigma_and_mask():
+    prediction = jnp.array([[[2.0, 1.0]]])
+    target = jnp.array([[[1.0, 2.0]]])
+    sigma = jnp.array([[[0.5, 1.0]]])
+    mask = jnp.array([[[1.0, 0.0]]])
+
+    products = compute_residual_products(
+        prediction=prediction,
+        target=target,
+        sigma=sigma,
+        mask=mask,
+    )
+
+    assert set(products.keys()) == {
+        "residual",
+        "abs_residual",
+        "chi2",
+        "masked_residual",
+        "masked_chi2",
+    }
+    assert jnp.allclose(products["chi2"], jnp.array([[[4.0, 1.0]]]))
+    assert jnp.allclose(products["masked_chi2"], jnp.array([[[4.0, 0.0]]]))
+
+
+def test_summarize_masked_metrics_matches_expected_values():
+    prediction = jnp.array([[[2.0, 0.0]]])
+    target = jnp.array([[[1.0, 2.0]]])
+    mask = jnp.array([[[1.0, 0.0]]])
+
+    metrics = summarize_masked_metrics(prediction, target, mask=mask)
+
+    assert pytest.approx(metrics["mse"]) == 1.0
+    assert pytest.approx(metrics["mae"]) == 1.0

--- a/tests/test_inference_workflows.py
+++ b/tests/test_inference_workflows.py
@@ -1,0 +1,65 @@
+import json
+
+import numpy as np
+
+from rubix.inference.workflows import (
+    run_synthetic_science_recipe,
+    save_science_recipe_outputs,
+)
+
+
+def test_run_synthetic_science_recipe_returns_expected_structure():
+    outputs = run_synthetic_science_recipe(
+        cube_shape=(2, 2, 4),
+        target_scale=1.5,
+        optimize_steps=20,
+        vi_steps=20,
+        num_vi_samples=2,
+        num_posterior_draws=4,
+        seed=0,
+    )
+
+    assert "config" in outputs
+    assert "optimization" in outputs
+    assert "variational" in outputs
+    assert "predictive_summary" in outputs
+    assert "residual_products" in outputs
+    assert "metrics" in outputs
+
+    assert outputs["predictive_summary"]["mean"].shape == (2, 2, 4)
+    assert outputs["residual_products"]["residual"].shape == (2, 2, 4)
+    assert outputs["metrics"]["mse"] >= 0.0
+    assert outputs["metrics"]["mae"] >= 0.0
+
+
+def test_save_science_recipe_outputs_writes_json_and_npz(tmp_path):
+    outputs = run_synthetic_science_recipe(
+        cube_shape=(2, 2, 4),
+        target_scale=1.2,
+        optimize_steps=10,
+        vi_steps=10,
+        num_vi_samples=2,
+        num_posterior_draws=3,
+        seed=1,
+    )
+
+    save_science_recipe_outputs(outputs, str(tmp_path))
+
+    summary_path = tmp_path / "summary.json"
+    predictive_path = tmp_path / "predictive_summary.npz"
+    residual_path = tmp_path / "residual_products.npz"
+
+    assert summary_path.exists()
+    assert predictive_path.exists()
+    assert residual_path.exists()
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["config"]["cube_shape"] == [2, 2, 4]
+    assert "final_loss" in summary["optimization"]
+    assert "final_objective" in summary["variational"]
+
+    predictive = np.load(predictive_path)
+    residual = np.load(residual_path)
+
+    assert predictive["mean"].shape == (2, 2, 4)
+    assert residual["residual"].shape == (2, 2, 4)


### PR DESCRIPTION
## Summary
- add posterior predictive sampling utilities for VI outputs
- add predictive summary maps (mean/std/p16/p50/p84)
- add residual/chi2 products and masked scalar metrics helpers
- export utilities in rubix.inference
- add focused unit tests and workflow docs

## Validation
- pre-commit passed on changed files
- compileall passed for module and tests