### PR TITLE
feat(inference): add production IFU experiment runner

### DIFF
--- a/bench/check_inference_guardrails.py
+++ b/bench/check_inference_guardrails.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+import argparse
+import json
+from pathlib import Path
+
+import jax.numpy as jnp
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference import (
+    OptimizationObjectiveThresholds,
+    RuntimeThresholds,
+    benchmark_ifu_cube_optimization,
+    benchmark_result_to_dict,
+    check_ifu_optimization_guardrails,
+)
+
+
+class _SyntheticPipeline:
+    """Small synthetic pipeline for guardrail smoke checks."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        return rubixdata.stars.age[0] * self.template
+
+
+def _make_data() -> RubixData:
+    return RubixData(
+        galaxy=Galaxy(),
+        stars=StarsData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+            age=jnp.array([0.0]),
+            metallicity=jnp.array([0.01]),
+        ),
+        gas=GasData(
+            coords=jnp.zeros((1, 3)),
+            velocity=jnp.zeros((1, 3)),
+            mass=jnp.ones(1),
+        ),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run optimization benchmark and assert runtime/loss guardrails."
+    )
+    parser.add_argument("--nx", type=int, default=8)
+    parser.add_argument("--ny", type=int, default=8)
+    parser.add_argument("--nw", type=int, default=64)
+    parser.add_argument("--max-steps", type=int, default=120)
+    parser.add_argument("--repeats", type=int, default=2)
+    parser.add_argument("--max-mean-runtime-s", type=float, default=3.0)
+    parser.add_argument("--max-median-runtime-s", type=float, default=3.0)
+    parser.add_argument("--max-final-loss", type=float, default=1e-3)
+    parser.add_argument("--max-best-loss", type=float, default=1e-3)
+    parser.add_argument("--output-json", type=str, default="")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    cube = jnp.ones((args.nx, args.ny, args.nw), dtype=jnp.float32)
+    target = 1.5 * cube
+
+    benchmark_result = benchmark_ifu_cube_optimization(
+        pipeline=_SyntheticPipeline(cube),
+        params_init={"stars": {"age": jnp.array([0.2])}},
+        static_data=_make_data(),
+        target=target,
+        learning_rate=0.1,
+        max_steps=args.max_steps,
+        tol=1e-8,
+        repeats=args.repeats,
+        warmup=True,
+    )
+
+    runtime_thresholds = RuntimeThresholds(
+        max_mean_runtime_s=args.max_mean_runtime_s,
+        max_median_runtime_s=args.max_median_runtime_s,
+    )
+    objective_thresholds = OptimizationObjectiveThresholds(
+        max_final_loss=args.max_final_loss,
+        max_best_loss=args.max_best_loss,
+    )
+
+    check = check_ifu_optimization_guardrails(
+        benchmark_result,
+        runtime_thresholds,
+        objective_thresholds,
+    )
+
+    payload = {
+        "benchmark": benchmark_result_to_dict(benchmark_result),
+        "guardrail": {
+            "passed": check.passed,
+            "message": check.message,
+            "failed_conditions": check.failed_conditions,
+        },
+    }
+
+    if args.output_json:
+        output_path = Path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    if not check.passed:
+        raise SystemExit(check.message)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -320,6 +320,48 @@ residual metrics) and persist science-ready outputs:
      --vi-steps 200 \
      --num-posterior-draws 16
 
+
+Production IFU Experiment
+-------------------------
+
+Run a full configuration-driven IFU experiment with optional checkpointing and
+resume support:
+
+.. code-block:: bash
+
+   python scripts/run_ifu_science_experiment.py \
+     --config rubix/config/inference_experiment_template.yml
+
+The template supports:
+
+- deterministic or stochastic mode selection
+- runtime objective selection via ``run.objective``
+- chunked optimization/VI with stage checkpoints
+- posterior predictive output products and masked science metrics
+
+
+Real Data Runbook
+-----------------
+
+1. Prepare cube-side arrays as ``.npy`` or ``.npz`` files with matching
+   ``(nx, ny, nw)`` shapes:
+   ``target``, optional ``mask``, optional ``weights``, optional ``sigma`` or
+   ``inv_variance``.
+2. Copy and edit
+   ``rubix/config/inference_experiment_template.yml``:
+   set ``run.rubix_config_path``, ``data.*_path``, and stage hyperparameters.
+3. Run deterministic fitting first:
+
+   .. code-block:: bash
+
+      python scripts/run_ifu_science_experiment.py \
+        --config rubix/config/inference_experiment_template.yml
+
+4. If interrupted, resume from latest stage checkpoint by setting
+   ``optimization.resume_checkpoint`` or ``variational.resume_checkpoint``.
+5. Inspect outputs in ``run.output_dir``:
+   ``summary.json``, ``predictive_summary.npz``, ``residual_products.npz``.
+
 Benchmarking Full-IFU Optimization
 ----------------------------------
 
@@ -333,3 +375,14 @@ memory diagnostics for full IFU cubes.
      --repeats 3 \
      --max-steps 200 \
      --use-mask --use-weights
+
+For CI-style threshold checks on a representative synthetic IFU size:
+
+.. code-block:: bash
+
+   python bench/check_inference_guardrails.py \
+     --nx 8 --ny 8 --nw 64 \
+     --max-steps 120 \
+     --max-mean-runtime-s 3.0 \
+     --max-final-loss 1e-3 \
+     --output-json outputs/guardrails/opt_guardrail.json

--- a/docs/rubix.inference.rst
+++ b/docs/rubix.inference.rst
@@ -20,6 +20,14 @@ rubix.inference.checkpoint module
    :undoc-members:
    :show-inheritance:
 
+rubix.inference.experiment module
+---------------------------------
+
+.. automodule:: rubix.inference.experiment
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 rubix.inference.losses module
 -----------------------------
 

--- a/rubix/config/inference_experiment_template.yml
+++ b/rubix/config/inference_experiment_template.yml
@@ -1,0 +1,60 @@
+run:
+  rubix_config_path: rubix/config/rubix_config.yml
+  mode: deterministic
+  seed: 0
+  noise_seed: 0
+  output_dir: outputs/ifu_science
+  checkpoint_dir: outputs/ifu_science/checkpoints
+  params_init_overrides:
+    stars:
+      age: [1.0]
+      metallicity: [0.01]
+  objective:
+    kind: combined
+    terms:
+      - kind: gaussian_nll
+        inv_variance_key: inv_variance
+        mask_key: mask
+      - kind: huber
+        delta: 0.2
+        mask_key: mask
+        weight: 0.05
+
+data:
+  target_path: data/target_cube.npy
+  target_key:
+  mask_path: data/mask_cube.npy
+  mask_key:
+  weights_path:
+  weights_key:
+  sigma_path:
+  sigma_key:
+  inv_variance_path: data/inv_variance_cube.npy
+  inv_variance_key:
+
+optimization:
+  enabled: true
+  learning_rate: 0.001
+  max_steps: 500
+  tol: 1.0e-6
+  normalize_loss: true
+  checkpoint_interval_steps: 100
+  resume_checkpoint:
+
+variational:
+  enabled: true
+  learning_rate: 0.005
+  max_steps: 500
+  tol: 1.0e-6
+  num_samples: 4
+  beta_kl: 0.001
+  init_log_std: -2.0
+  normalize_loss: true
+  huber_delta: 0.2
+  huber_weight: 0.0
+  checkpoint_interval_steps: 100
+  resume_checkpoint:
+
+predictive:
+  enabled: true
+  num_draws: 16

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -16,6 +16,11 @@ from .checkpoint import (
     resume_variational_from_checkpoint,
     save_checkpoint,
 )
+from .experiment import (
+    normalize_experiment_config,
+    run_ifu_experiment,
+    save_ifu_experiment_outputs,
+)
 from .losses import combine_loss_fns, huber_data_loss, masked_gaussian_nll
 from .modes import get_pipeline_name_for_mode, make_inference_pipeline
 from .objective_config import build_loss_from_config, build_loss_from_user_config
@@ -87,6 +92,7 @@ __all__ = [
     "load_checkpoint",
     "make_optimization_checkpoint",
     "make_variational_checkpoint",
+    "normalize_experiment_config",
     "build_age_metallicity_transforms",
     "build_ifu_cube_loss",
     "build_loss_from_config",
@@ -124,6 +130,8 @@ __all__ = [
     "summarize_masked_metrics",
     "summarize_predictive_cube_samples",
     "save_checkpoint",
+    "run_ifu_experiment",
+    "save_ifu_experiment_outputs",
     "value_and_grad",
     "run_synthetic_science_recipe",
     "save_science_recipe_outputs",

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1,0 +1,856 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from rubix.core.data import RubixData
+from rubix.utils import get_config, read_yaml
+
+from .checkpoint import (
+    load_checkpoint,
+    make_optimization_checkpoint,
+    make_variational_checkpoint,
+    save_checkpoint,
+)
+from .modes import InferenceMode, make_inference_pipeline
+from .objective_config import build_loss_from_config
+from .optimize import (
+    OptimizationResult,
+    OptimizationState,
+    optimize_ifu_cube,
+    optimize_params,
+)
+from .posterior_predictive import (
+    compute_residual_products,
+    sample_posterior_predictive_cubes,
+    summarize_masked_metrics,
+    summarize_predictive_cube_samples,
+)
+from .variational import (
+    VariationalResult,
+    VariationalState,
+    optimize_variational_ifu_cube,
+    optimize_variational_posterior,
+)
+from .workflows import _to_jsonable
+
+ExperimentConfigInput = Union[str, Mapping[str, Any]]
+PipelineFactory = Callable[[dict[str, Any], InferenceMode], Any]
+
+
+class _PreparedPipeline:
+    """Container for prepared pipeline and static data."""
+
+    def __init__(self, pipeline: Any, static_data: RubixData):
+        self.pipeline = pipeline
+        self.static_data = static_data
+
+
+def _load_array(path: str, key: Optional[str] = None) -> jnp.ndarray:
+    """Load an array from ``.npy`` or ``.npz`` and return JAX array.
+
+    Args:
+        path (str): Array file path.
+        key (Optional[str], optional): Required key for multi-array ``.npz`` files.
+            Defaults to ``None``.
+
+    Raises:
+        ValueError: If the file extension is unsupported, key resolution fails,
+            or the loaded value is not array-like.
+
+    Returns:
+        jnp.ndarray: Loaded array.
+    """
+    array_path = Path(path)
+    suffix = array_path.suffix.lower()
+
+    if suffix == ".npy":
+        arr = np.load(array_path)
+    elif suffix == ".npz":
+        with np.load(array_path) as npz:
+            if key is not None:
+                if key not in npz.files:
+                    raise ValueError(
+                        f"key '{key}' not found in {path}; keys={npz.files}"
+                    )
+                arr = npz[key]
+            elif len(npz.files) == 1:
+                arr = npz[npz.files[0]]
+            else:
+                raise ValueError(
+                    f"npz file {path} contains multiple arrays {npz.files}; provide a key"
+                )
+    else:
+        raise ValueError(f"unsupported array format for {path}; expected .npy or .npz")
+
+    return jnp.asarray(arr)
+
+
+def _default_params_init(static_data: RubixData) -> dict[str, dict[str, Any]]:
+    """Build default parameter initialization from present RubixData fields.
+
+    Args:
+        static_data (RubixData): Prepared static pipeline data.
+
+    Raises:
+        ValueError: If no supported default parameter fields are available.
+
+    Returns:
+        dict[str, dict[str, Any]]: Nested parameter tree for inference.
+    """
+    params: dict[str, dict[str, Any]] = {}
+
+    if static_data.stars is not None:
+        stars_updates: dict[str, Any] = {}
+        if static_data.stars.age is not None:
+            stars_updates["age"] = jnp.asarray(static_data.stars.age)
+        if static_data.stars.metallicity is not None:
+            stars_updates["metallicity"] = jnp.asarray(static_data.stars.metallicity)
+        if len(stars_updates) > 0:
+            params["stars"] = stars_updates
+
+    if static_data.gas is not None:
+        gas_updates: dict[str, Any] = {}
+        if static_data.gas.metallicity is not None:
+            gas_updates["metallicity"] = jnp.asarray(static_data.gas.metallicity)
+        if len(gas_updates) > 0:
+            params["gas"] = gas_updates
+
+    if len(params) == 0:
+        raise ValueError(
+            "could not infer params_init from static_data; provide params_init_overrides"
+        )
+
+    return params
+
+
+def _apply_params_overrides(
+    params_init: Mapping[str, Mapping[str, Any]],
+    overrides: Mapping[str, Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Apply nested parameter overrides to ``params_init``.
+
+    Args:
+        params_init (Mapping[str, Mapping[str, Any]]): Baseline initialization.
+        overrides (Mapping[str, Mapping[str, Any]]): Nested override mapping.
+
+    Raises:
+        ValueError: If overrides are not nested mappings.
+
+    Returns:
+        dict[str, dict[str, Any]]: Updated initialization tree.
+    """
+    merged = {component: dict(fields) for component, fields in params_init.items()}
+    for component, fields in overrides.items():
+        if not isinstance(fields, Mapping):
+            raise ValueError(f"params_init_overrides[{component!r}] must be a mapping")
+        component_dict = merged.setdefault(component, {})
+        for field, value in fields.items():
+            component_dict[field] = jnp.asarray(value)
+    return merged
+
+
+def _is_finite_scalar(value: float) -> bool:
+    """Return ``True`` when scalar value is finite.
+
+    Args:
+        value (float): Scalar to evaluate.
+
+    Returns:
+        bool: ``True`` if finite.
+    """
+    return bool(np.isfinite(value))
+
+
+def normalize_experiment_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize a production IFU experiment config mapping.
+
+    Expected sections are ``run``, ``data``, ``optimization``, ``variational``,
+    and ``predictive``.
+
+    Args:
+        config (Mapping[str, Any]): Raw user mapping.
+
+    Raises:
+        ValueError: If required keys are missing or malformed.
+
+    Returns:
+        dict[str, Any]: Normalized config with defaults.
+    """
+    run_cfg = dict(config.get("run") or {})
+    data_cfg = dict(config.get("data") or {})
+    opt_cfg = dict(config.get("optimization") or {})
+    vi_cfg = dict(config.get("variational") or {})
+    pred_cfg = dict(config.get("predictive") or {})
+
+    rubix_config_path = run_cfg.get("rubix_config_path")
+    target_path = data_cfg.get("target_path")
+
+    if not isinstance(rubix_config_path, str) or len(rubix_config_path.strip()) == 0:
+        raise ValueError("run.rubix_config_path must be a non-empty string")
+
+    if not isinstance(target_path, str) or len(target_path.strip()) == 0:
+        raise ValueError("data.target_path must be a non-empty string")
+
+    mode = run_cfg.get("mode", "deterministic")
+    if mode not in {"deterministic", "stochastic"}:
+        raise ValueError("run.mode must be 'deterministic' or 'stochastic'")
+
+    normalized = {
+        "run": {
+            "rubix_config_path": rubix_config_path,
+            "mode": mode,
+            "seed": int(run_cfg.get("seed", 0)),
+            "output_dir": run_cfg.get("output_dir", "outputs/ifu_science"),
+            "checkpoint_dir": run_cfg.get("checkpoint_dir"),
+            "params_init_overrides": dict(run_cfg.get("params_init_overrides") or {}),
+            "objective": run_cfg.get("objective"),
+            "noise_seed": run_cfg.get("noise_seed"),
+        },
+        "data": {
+            "target_path": target_path,
+            "target_key": data_cfg.get("target_key"),
+            "mask_path": data_cfg.get("mask_path"),
+            "mask_key": data_cfg.get("mask_key"),
+            "weights_path": data_cfg.get("weights_path"),
+            "weights_key": data_cfg.get("weights_key"),
+            "sigma_path": data_cfg.get("sigma_path"),
+            "sigma_key": data_cfg.get("sigma_key"),
+            "inv_variance_path": data_cfg.get("inv_variance_path"),
+            "inv_variance_key": data_cfg.get("inv_variance_key"),
+        },
+        "optimization": {
+            "enabled": bool(opt_cfg.get("enabled", True)),
+            "learning_rate": float(opt_cfg.get("learning_rate", 1e-3)),
+            "max_steps": int(opt_cfg.get("max_steps", 400)),
+            "tol": float(opt_cfg.get("tol", 1e-6)),
+            "normalize_loss": bool(opt_cfg.get("normalize_loss", True)),
+            "checkpoint_interval_steps": opt_cfg.get("checkpoint_interval_steps"),
+            "resume_checkpoint": opt_cfg.get("resume_checkpoint"),
+        },
+        "variational": {
+            "enabled": bool(vi_cfg.get("enabled", True)),
+            "learning_rate": float(vi_cfg.get("learning_rate", 5e-3)),
+            "max_steps": int(vi_cfg.get("max_steps", 400)),
+            "tol": float(vi_cfg.get("tol", 1e-6)),
+            "num_samples": int(vi_cfg.get("num_samples", 4)),
+            "beta_kl": float(vi_cfg.get("beta_kl", 1e-3)),
+            "init_log_std": float(vi_cfg.get("init_log_std", -2.0)),
+            "normalize_loss": bool(vi_cfg.get("normalize_loss", True)),
+            "huber_delta": vi_cfg.get("huber_delta"),
+            "huber_weight": float(vi_cfg.get("huber_weight", 0.0)),
+            "checkpoint_interval_steps": vi_cfg.get("checkpoint_interval_steps"),
+            "resume_checkpoint": vi_cfg.get("resume_checkpoint"),
+        },
+        "predictive": {
+            "enabled": bool(pred_cfg.get("enabled", True)),
+            "num_draws": int(pred_cfg.get("num_draws", 16)),
+        },
+    }
+
+    for stage_name in ["optimization", "variational"]:
+        interval = normalized[stage_name]["checkpoint_interval_steps"]
+        if interval is not None:
+            interval_int = int(interval)
+            if interval_int <= 0:
+                raise ValueError(
+                    f"{stage_name}.checkpoint_interval_steps must be positive if provided"
+                )
+            normalized[stage_name]["checkpoint_interval_steps"] = interval_int
+
+    return normalized
+
+
+def _prepare_pipeline(
+    rubix_config_path: str,
+    mode: InferenceMode,
+    pipeline_factory: PipelineFactory,
+) -> _PreparedPipeline:
+    """Build inference pipeline and static data from Rubix config.
+
+    Args:
+        rubix_config_path (str): Path to Rubix user config yaml.
+        mode (InferenceMode): Deterministic or stochastic mode.
+        pipeline_factory (PipelineFactory): Builder callable.
+
+    Returns:
+        _PreparedPipeline: Prepared container with pipeline and static data.
+    """
+    user_config = get_config(rubix_config_path)
+    pipeline = pipeline_factory(user_config, mode=mode)
+    static_data = pipeline.prepare_data()
+    return _PreparedPipeline(pipeline=pipeline, static_data=static_data)
+
+
+def _resolve_data_tensors(
+    data_cfg: Mapping[str, Any],
+) -> dict[str, Optional[jnp.ndarray]]:
+    """Load target and optional cube-side tensors from configured paths.
+
+    Args:
+        data_cfg (Mapping[str, Any]): Normalized ``data`` config section.
+
+    Returns:
+        dict[str, Optional[jnp.ndarray]]: Loaded tensors.
+    """
+
+    def maybe_load(path_key: str, key_key: str) -> Optional[jnp.ndarray]:
+        path_value = data_cfg.get(path_key)
+        if path_value is None:
+            return None
+        return _load_array(path=str(path_value), key=data_cfg.get(key_key))
+
+    target = _load_array(
+        path=str(data_cfg["target_path"]),
+        key=data_cfg.get("target_key"),
+    )
+
+    mask = maybe_load("mask_path", "mask_key")
+    weights = maybe_load("weights_path", "weights_key")
+    sigma = maybe_load("sigma_path", "sigma_key")
+    inv_variance = maybe_load("inv_variance_path", "inv_variance_key")
+
+    return {
+        "target": target,
+        "mask": mask,
+        "weights": weights,
+        "sigma": sigma,
+        "inv_variance": inv_variance,
+    }
+
+
+def _checkpoint_path(directory: str, stage: str, chunk_idx: int) -> str:
+    """Build checkpoint path for a given stage chunk.
+
+    Args:
+        directory (str): Checkpoint directory.
+        stage (str): Stage name.
+        chunk_idx (int): Chunk index.
+
+    Returns:
+        str: Checkpoint file path.
+    """
+    return str(Path(directory) / f"{stage}_chunk_{chunk_idx:04d}.pkl")
+
+
+def _run_optimization_stage(
+    pipeline: Any,
+    params_init: Mapping[str, Mapping[str, Any]],
+    static_data: RubixData,
+    target: jnp.ndarray,
+    mask: Optional[jnp.ndarray],
+    weights: Optional[jnp.ndarray],
+    noise_key: Optional[jnp.ndarray],
+    objective_loss_fn: Optional[Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]],
+    stage_cfg: Mapping[str, Any],
+    checkpoint_dir: Optional[str],
+) -> tuple[Optional[OptimizationResult], Optional[OptimizationState], dict[str, Any]]:
+    """Run optimization stage with optional checkpoint cadence and resume.
+
+    Args:
+        pipeline (Any): Inference pipeline with ``run_sharded``.
+        params_init (Mapping[str, Mapping[str, Any]]): Initial params.
+        static_data (RubixData): Static data tree.
+        target (jnp.ndarray): Target IFU cube.
+        mask (Optional[jnp.ndarray]): Optional mask.
+        weights (Optional[jnp.ndarray]): Optional weights.
+        noise_key (Optional[jnp.ndarray]): Optional stochastic key.
+        objective_loss_fn (Optional[Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]]):
+            Optional custom objective callable.
+        stage_cfg (Mapping[str, Any]): Normalized optimization config.
+        checkpoint_dir (Optional[str]): Optional checkpoint output directory.
+
+    Raises:
+        ValueError: If ``resume_checkpoint`` exists but is not an optimization
+            checkpoint payload.
+
+    Returns:
+        tuple[Optional[OptimizationResult], Optional[OptimizationState], dict[str, Any]]:
+            Latest result, latest state, and stage metadata.
+    """
+    if not stage_cfg["enabled"]:
+        return None, None, {"status": "skipped", "reason": "disabled"}
+
+    remaining = int(stage_cfg["max_steps"])
+    interval = stage_cfg["checkpoint_interval_steps"]
+    if interval is None:
+        interval = remaining
+
+    state_init: Optional[OptimizationState] = None
+    current_params = {
+        component: dict(fields) for component, fields in params_init.items()
+    }
+    latest_result: Optional[OptimizationResult] = None
+    latest_state: Optional[OptimizationState] = None
+    chunk_idx = 0
+    steps_completed = 0
+
+    resume_checkpoint = stage_cfg.get("resume_checkpoint")
+    if isinstance(resume_checkpoint, str) and len(resume_checkpoint) > 0:
+        payload = load_checkpoint(resume_checkpoint)
+        if payload.get("kind") != "optimization":
+            raise ValueError(
+                "optimization.resume_checkpoint must reference optimization"
+            )
+        latest_result = payload["result"]
+        latest_state = payload["state"]
+        state_init = latest_state
+        current_params = latest_result.params
+        steps_completed = int(latest_result.steps_run)
+        remaining = max(0, remaining - steps_completed)
+
+    while remaining > 0:
+        run_steps = min(remaining, interval)
+        chunk_idx += 1
+
+        if objective_loss_fn is None:
+            result, state = optimize_ifu_cube(
+                pipeline=pipeline,
+                params_init=current_params,
+                static_data=static_data,
+                target=target,
+                mask=mask,
+                weights=weights,
+                normalize_loss=bool(stage_cfg["normalize_loss"]),
+                learning_rate=float(stage_cfg["learning_rate"]),
+                max_steps=int(run_steps),
+                tol=float(stage_cfg["tol"]),
+                noise_key=noise_key,
+                state_init=state_init,
+                return_state=True,
+            )
+        else:
+            result, state = optimize_params(
+                pipeline=pipeline,
+                params_init=current_params,
+                static_data=static_data,
+                target=target,
+                learning_rate=float(stage_cfg["learning_rate"]),
+                max_steps=int(run_steps),
+                tol=float(stage_cfg["tol"]),
+                loss_fn=objective_loss_fn,
+                noise_key=noise_key,
+                state_init=state_init,
+                return_state=True,
+            )
+
+        latest_result = result
+        latest_state = state
+        current_params = result.params
+        state_init = state
+
+        steps_completed += int(result.steps_run)
+        remaining -= int(result.steps_run)
+
+        if checkpoint_dir is not None:
+            ckpt_payload = make_optimization_checkpoint(
+                result=result,
+                state=state,
+                learning_rate=float(stage_cfg["learning_rate"]),
+                tol=float(stage_cfg["tol"]),
+                metadata={"stage": "optimization", "steps_completed": steps_completed},
+            )
+            save_checkpoint(
+                _checkpoint_path(checkpoint_dir, "optimization", chunk_idx),
+                ckpt_payload,
+            )
+
+        if not _is_finite_scalar(result.final_loss):
+            return (
+                latest_result,
+                latest_state,
+                {
+                    "status": "failed",
+                    "reason": "non_finite_final_loss",
+                    "steps_completed": steps_completed,
+                },
+            )
+
+        if result.converged or result.steps_run < run_steps:
+            break
+
+    if latest_result is None:
+        return None, None, {"status": "skipped", "reason": "no_steps"}
+
+    return (
+        latest_result,
+        latest_state,
+        {
+            "status": "completed",
+            "converged": bool(latest_result.converged),
+            "steps_completed": steps_completed,
+            "final_loss": float(latest_result.final_loss),
+        },
+    )
+
+
+def _run_variational_stage(
+    pipeline: Any,
+    params_init: Mapping[str, Mapping[str, Any]],
+    static_data: RubixData,
+    target: jnp.ndarray,
+    sigma: Optional[jnp.ndarray],
+    inv_variance: Optional[jnp.ndarray],
+    mask: Optional[jnp.ndarray],
+    noise_key: Optional[jnp.ndarray],
+    objective_loss_fn: Optional[Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]],
+    stage_cfg: Mapping[str, Any],
+    checkpoint_dir: Optional[str],
+    seed: int,
+) -> tuple[Optional[VariationalResult], Optional[VariationalState], dict[str, Any]]:
+    """Run VI stage with optional checkpoint cadence and resume.
+
+    Args:
+        pipeline (Any): Inference pipeline with ``run_sharded``.
+        params_init (Mapping[str, Mapping[str, Any]]): Initial constrained params.
+        static_data (RubixData): Static data tree.
+        target (jnp.ndarray): Target IFU cube.
+        sigma (Optional[jnp.ndarray]): Optional sigma map.
+        inv_variance (Optional[jnp.ndarray]): Optional inverse variance map.
+        mask (Optional[jnp.ndarray]): Optional mask.
+        noise_key (Optional[jnp.ndarray]): Optional stochastic key.
+        objective_loss_fn (Optional[Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]]):
+            Optional custom objective callable.
+        stage_cfg (Mapping[str, Any]): Normalized variational config.
+        checkpoint_dir (Optional[str]): Optional checkpoint output directory.
+        seed (int): Random seed.
+
+    Raises:
+        ValueError: If ``resume_checkpoint`` exists but is not a variational
+            checkpoint payload.
+
+    Returns:
+        tuple[Optional[VariationalResult], Optional[VariationalState], dict[str, Any]]:
+            Latest result, latest state, and stage metadata.
+    """
+    if not stage_cfg["enabled"]:
+        return None, None, {"status": "skipped", "reason": "disabled"}
+
+    remaining = int(stage_cfg["max_steps"])
+    interval = stage_cfg["checkpoint_interval_steps"]
+    if interval is None:
+        interval = remaining
+
+    state_init: Optional[VariationalState] = None
+    current_params = {
+        component: dict(fields) for component, fields in params_init.items()
+    }
+    latest_result: Optional[VariationalResult] = None
+    latest_state: Optional[VariationalState] = None
+    chunk_idx = 0
+    steps_completed = 0
+
+    resume_checkpoint = stage_cfg.get("resume_checkpoint")
+    if isinstance(resume_checkpoint, str) and len(resume_checkpoint) > 0:
+        payload = load_checkpoint(resume_checkpoint)
+        if payload.get("kind") != "variational":
+            raise ValueError("variational.resume_checkpoint must reference variational")
+        latest_result = payload["result"]
+        latest_state = payload["state"]
+        state_init = latest_state
+        current_params = latest_result.posterior_mean_constrained_params
+        steps_completed = int(latest_result.steps_run)
+        remaining = max(0, remaining - steps_completed)
+
+    while remaining > 0:
+        run_steps = min(remaining, interval)
+        chunk_idx += 1
+
+        if objective_loss_fn is None:
+            result, state = optimize_variational_ifu_cube(
+                pipeline=pipeline,
+                params_init=current_params,
+                static_data=static_data,
+                target=target,
+                sigma=sigma,
+                inv_variance=inv_variance,
+                mask=mask,
+                normalize_loss=bool(stage_cfg["normalize_loss"]),
+                huber_delta=stage_cfg["huber_delta"],
+                huber_weight=float(stage_cfg["huber_weight"]),
+                learning_rate=float(stage_cfg["learning_rate"]),
+                max_steps=int(run_steps),
+                tol=float(stage_cfg["tol"]),
+                num_samples=int(stage_cfg["num_samples"]),
+                beta_kl=float(stage_cfg["beta_kl"]),
+                init_log_std=float(stage_cfg["init_log_std"]),
+                noise_key=noise_key,
+                seed=int(seed),
+                state_init=state_init,
+                return_state=True,
+            )
+        else:
+            result, state = optimize_variational_posterior(
+                pipeline=pipeline,
+                params_init=current_params,
+                static_data=static_data,
+                target=target,
+                learning_rate=float(stage_cfg["learning_rate"]),
+                max_steps=int(run_steps),
+                tol=float(stage_cfg["tol"]),
+                num_samples=int(stage_cfg["num_samples"]),
+                beta_kl=float(stage_cfg["beta_kl"]),
+                init_log_std=float(stage_cfg["init_log_std"]),
+                loss_fn=objective_loss_fn,
+                noise_key=noise_key,
+                seed=int(seed),
+                state_init=state_init,
+                return_state=True,
+            )
+
+        latest_result = result
+        latest_state = state
+        current_params = result.posterior_mean_constrained_params
+        state_init = state
+
+        steps_completed += int(result.steps_run)
+        remaining -= int(result.steps_run)
+
+        if checkpoint_dir is not None:
+            ckpt_payload = make_variational_checkpoint(
+                result=result,
+                state=state,
+                learning_rate=float(stage_cfg["learning_rate"]),
+                tol=float(stage_cfg["tol"]),
+                num_samples=int(stage_cfg["num_samples"]),
+                beta_kl=float(stage_cfg["beta_kl"]),
+                init_log_std=float(stage_cfg["init_log_std"]),
+                seed=int(seed),
+                metadata={"stage": "variational", "steps_completed": steps_completed},
+            )
+            save_checkpoint(
+                _checkpoint_path(checkpoint_dir, "variational", chunk_idx), ckpt_payload
+            )
+
+        if not _is_finite_scalar(result.final_objective):
+            return (
+                latest_result,
+                latest_state,
+                {
+                    "status": "failed",
+                    "reason": "non_finite_final_objective",
+                    "steps_completed": steps_completed,
+                },
+            )
+
+        if result.converged or result.steps_run < run_steps:
+            break
+
+    if latest_result is None:
+        return None, None, {"status": "skipped", "reason": "no_steps"}
+
+    return (
+        latest_result,
+        latest_state,
+        {
+            "status": "completed",
+            "converged": bool(latest_result.converged),
+            "steps_completed": steps_completed,
+            "final_objective": float(latest_result.final_objective),
+        },
+    )
+
+
+def run_ifu_experiment(
+    config: ExperimentConfigInput,
+    pipeline_factory: PipelineFactory = make_inference_pipeline,
+) -> dict[str, Any]:
+    """Run a production IFU inference experiment from config.
+
+    This orchestration supports deterministic/stochastic pipeline mode, objective
+    config selection, optimization and VI stages, posterior predictive outputs,
+    periodic checkpoints, and resume from stage checkpoints.
+
+    Args:
+        config (ExperimentConfigInput): Mapping or YAML path following the
+            experiment schema consumed by :func:`normalize_experiment_config`.
+        pipeline_factory (PipelineFactory, optional): Pipeline builder used to
+            instantiate and prepare a Rubix pipeline. Defaults to
+            :func:`make_inference_pipeline`.
+
+    Returns:
+        dict[str, Any]: Structured outputs including stage summaries, optional
+        predictive outputs, residual maps, and scalar metrics.
+    """
+    raw_cfg = read_yaml(config) if isinstance(config, str) else dict(config)
+    cfg = normalize_experiment_config(raw_cfg)
+
+    run_cfg = cfg["run"]
+    data_cfg = cfg["data"]
+
+    prepared = _prepare_pipeline(
+        rubix_config_path=str(run_cfg["rubix_config_path"]),
+        mode=run_cfg["mode"],
+        pipeline_factory=pipeline_factory,
+    )
+
+    tensors = _resolve_data_tensors(data_cfg)
+    target = tensors["target"]
+    mask = tensors["mask"]
+    weights = tensors["weights"]
+    sigma = tensors["sigma"]
+    inv_variance = tensors["inv_variance"]
+
+    params_init = _default_params_init(prepared.static_data)
+    params_init = _apply_params_overrides(params_init, run_cfg["params_init_overrides"])
+
+    objective_cfg = run_cfg.get("objective")
+    objective_loss_fn = None
+    if isinstance(objective_cfg, Mapping):
+        objective_loss_fn = build_loss_from_config(
+            objective_config=objective_cfg,
+            tensors={
+                "mask": mask,
+                "weights": weights,
+                "sigma": sigma,
+                "inv_variance": inv_variance,
+            },
+        )
+
+    noise_key = None
+    if run_cfg["mode"] == "stochastic":
+        noise_seed = run_cfg.get("noise_seed")
+        if noise_seed is None:
+            noise_seed = run_cfg["seed"]
+        noise_key = jax.random.PRNGKey(int(noise_seed))
+
+    checkpoint_dir = run_cfg.get("checkpoint_dir")
+    if checkpoint_dir is not None:
+        Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
+
+    opt_result, _, opt_status = _run_optimization_stage(
+        pipeline=prepared.pipeline,
+        params_init=params_init,
+        static_data=prepared.static_data,
+        target=target,
+        mask=mask,
+        weights=weights,
+        noise_key=noise_key,
+        objective_loss_fn=objective_loss_fn,
+        stage_cfg=cfg["optimization"],
+        checkpoint_dir=checkpoint_dir,
+    )
+
+    vi_params_init = params_init
+    if opt_result is not None and opt_status.get("status") == "completed":
+        vi_params_init = opt_result.params
+
+    vi_result, _, vi_status = _run_variational_stage(
+        pipeline=prepared.pipeline,
+        params_init=vi_params_init,
+        static_data=prepared.static_data,
+        target=target,
+        sigma=sigma,
+        inv_variance=inv_variance,
+        mask=mask,
+        noise_key=noise_key,
+        objective_loss_fn=objective_loss_fn,
+        stage_cfg=cfg["variational"],
+        checkpoint_dir=checkpoint_dir,
+        seed=int(run_cfg["seed"]),
+    )
+
+    outputs: dict[str, Any] = {
+        "config": cfg,
+        "stages": {
+            "optimization": opt_status,
+            "variational": vi_status,
+        },
+        "optimization": None,
+        "variational": None,
+        "predictive_summary": None,
+        "residual_products": None,
+        "metrics": None,
+    }
+
+    if opt_result is not None:
+        outputs["optimization"] = {
+            "final_loss": float(opt_result.final_loss),
+            "best_loss": float(opt_result.best_loss),
+            "steps_run": int(opt_result.steps_run),
+            "converged": bool(opt_result.converged),
+        }
+
+    if vi_result is not None:
+        outputs["variational"] = {
+            "final_objective": float(vi_result.final_objective),
+            "best_objective": float(vi_result.best_objective),
+            "steps_run": int(vi_result.steps_run),
+            "converged": bool(vi_result.converged),
+            "final_reconstruction": float(vi_result.final_reconstruction),
+            "final_kl": float(vi_result.final_kl),
+        }
+
+    if bool(cfg["predictive"]["enabled"]) and vi_result is not None:
+        predictive_samples = sample_posterior_predictive_cubes(
+            pipeline=prepared.pipeline,
+            posterior_mean_params=vi_result.posterior_mean_params,
+            posterior_log_std_params=vi_result.posterior_log_std_params,
+            static_data=prepared.static_data,
+            num_samples=int(cfg["predictive"]["num_draws"]),
+            noise_key=noise_key,
+            seed=int(run_cfg["seed"]) + 1,
+        )
+        predictive_summary = summarize_predictive_cube_samples(predictive_samples)
+        residual_products = compute_residual_products(
+            prediction=predictive_summary["mean"],
+            target=target,
+            sigma=sigma,
+            inv_variance=inv_variance,
+            mask=mask,
+        )
+        metrics = summarize_masked_metrics(
+            prediction=predictive_summary["mean"],
+            target=target,
+            mask=mask,
+            loss_fn=objective_loss_fn,
+        )
+
+        outputs["predictive_summary"] = predictive_summary
+        outputs["residual_products"] = residual_products
+        outputs["metrics"] = metrics
+
+    return outputs
+
+
+def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> None:
+    """Persist production IFU experiment outputs to JSON and NPZ artifacts.
+
+    Args:
+        outputs (Mapping[str, Any]): Outputs returned by
+            :func:`run_ifu_experiment`.
+        output_dir (str): Destination output directory.
+    """
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = {
+        "config": outputs.get("config"),
+        "stages": outputs.get("stages"),
+        "optimization": outputs.get("optimization"),
+        "variational": outputs.get("variational"),
+        "metrics": outputs.get("metrics"),
+    }
+    (out_dir / "summary.json").write_text(
+        json.dumps(_to_jsonable(summary), indent=2),
+        encoding="utf-8",
+    )
+
+    predictive_summary = outputs.get("predictive_summary")
+    if isinstance(predictive_summary, Mapping):
+        np.savez(
+            out_dir / "predictive_summary.npz",
+            **{k: np.asarray(v) for k, v in predictive_summary.items()},
+        )
+
+    residual_products = outputs.get("residual_products")
+    if isinstance(residual_products, Mapping):
+        np.savez(
+            out_dir / "residual_products.npz",
+            **{k: np.asarray(v) for k, v in residual_products.items()},
+        )

--- a/scripts/run_ifu_science_experiment.py
+++ b/scripts/run_ifu_science_experiment.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+import argparse
+
+from rubix.inference.experiment import run_ifu_experiment, save_ifu_experiment_outputs
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a production IFU inference experiment from YAML config."
+    )
+    parser.add_argument("--config", type=str, required=True)
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Override output directory from config.run.output_dir",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    outputs = run_ifu_experiment(args.config)
+
+    output_dir = args.output_dir
+    if output_dir is None:
+        output_dir = outputs["config"]["run"]["output_dir"]
+
+    save_ifu_experiment_outputs(outputs, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -1,0 +1,211 @@
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+import yaml
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference.checkpoint import (
+    make_optimization_checkpoint,
+    save_checkpoint,
+)
+from rubix.inference.experiment import (
+    normalize_experiment_config,
+    run_ifu_experiment,
+    save_ifu_experiment_outputs,
+)
+from rubix.inference.optimize import OptimizationResult, OptimizationState
+
+
+class PreparedSyntheticPipeline:
+    """Synthetic pipeline implementing prepare_data + run_sharded."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def prepare_data(self) -> RubixData:
+        return RubixData(
+            galaxy=Galaxy(),
+            stars=StarsData(
+                coords=jnp.zeros((1, 3)),
+                velocity=jnp.zeros((1, 3)),
+                mass=jnp.ones(1),
+                age=jnp.array([0.2]),
+                metallicity=jnp.array([0.01]),
+            ),
+            gas=GasData(
+                coords=jnp.zeros((1, 3)),
+                velocity=jnp.zeros((1, 3)),
+                mass=jnp.ones(1),
+            ),
+        )
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def _write_config(tmp_path: Path, target_path: str, checkpoint_dir: str) -> Path:
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+            "seed": 0,
+            "output_dir": str(tmp_path / "outputs"),
+            "checkpoint_dir": checkpoint_dir,
+            "params_init_overrides": {"stars": {"age": [0.2]}},
+        },
+        "data": {
+            "target_path": target_path,
+            "mask_path": str(tmp_path / "mask.npy"),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {
+            "enabled": True,
+            "learning_rate": 0.1,
+            "max_steps": 40,
+            "tol": 1e-8,
+            "checkpoint_interval_steps": 20,
+        },
+        "variational": {
+            "enabled": True,
+            "learning_rate": 0.05,
+            "max_steps": 40,
+            "tol": 1e-8,
+            "num_samples": 2,
+            "beta_kl": 1e-4,
+            "checkpoint_interval_steps": 20,
+        },
+        "predictive": {
+            "enabled": True,
+            "num_draws": 4,
+        },
+    }
+
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
+    config_path = tmp_path / "experiment.yml"
+    config_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return config_path
+
+
+def test_normalize_experiment_config_applies_defaults():
+    normalized = normalize_experiment_config(
+        {
+            "run": {"rubix_config_path": "conf.yml"},
+            "data": {"target_path": "target.npy"},
+        }
+    )
+
+    assert normalized["run"]["mode"] == "deterministic"
+    assert normalized["optimization"]["enabled"] is True
+    assert normalized["variational"]["enabled"] is True
+    assert normalized["predictive"]["num_draws"] == 16
+
+
+def test_run_ifu_experiment_and_save_outputs(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target = 1.5 * cube
+    mask = np.ones_like(target)
+    ivar = np.ones_like(target)
+
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, target)
+    np.save(tmp_path / "mask.npy", mask)
+    np.save(tmp_path / "ivar.npy", ivar)
+
+    checkpoint_dir = str(tmp_path / "checkpoints")
+    config_path = _write_config(tmp_path, str(target_path), checkpoint_dir)
+
+    def pipeline_factory(_cfg, mode):
+        assert mode == "deterministic"
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    outputs = run_ifu_experiment(str(config_path), pipeline_factory=pipeline_factory)
+
+    assert outputs["stages"]["optimization"]["status"] == "completed"
+    assert outputs["stages"]["variational"]["status"] == "completed"
+    assert outputs["metrics"]["mse"] >= 0.0
+    assert outputs["predictive_summary"]["mean"].shape == (2, 2, 4)
+
+    checkpoint_files = list((tmp_path / "checkpoints").glob("*.pkl"))
+    assert len(checkpoint_files) >= 2
+
+    save_ifu_experiment_outputs(outputs, str(tmp_path / "saved"))
+    assert (tmp_path / "saved" / "summary.json").exists()
+    assert (tmp_path / "saved" / "predictive_summary.npz").exists()
+    assert (tmp_path / "saved" / "residual_products.npz").exists()
+
+
+def test_normalize_experiment_config_rejects_invalid_checkpoint_interval():
+    try:
+        normalize_experiment_config(
+            {
+                "run": {"rubix_config_path": "conf.yml"},
+                "data": {"target_path": "target.npy"},
+                "optimization": {"checkpoint_interval_steps": 0},
+            }
+        )
+    except ValueError as exc:
+        assert "checkpoint_interval_steps" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for non-positive checkpoint interval")
+
+
+def test_run_ifu_experiment_rejects_mismatched_resume_checkpoint_kind(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\\n  name: calc_gradient\\n")
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+
+    opt_result = OptimizationResult(
+        params={"stars": {"age": jnp.array([0.2])}},
+        best_params={"stars": {"age": jnp.array([0.2])}},
+        loss_history=[1.0],
+        grad_norm_history=[1.0],
+        best_loss=1.0,
+        final_loss=1.0,
+        steps_run=1,
+        converged=False,
+    )
+    opt_state = OptimizationState(
+        trainable_params={"stars": {"age": jnp.array([0.2])}},
+        opt_state=None,
+        best_trainable_params={"stars": {"age": jnp.array([0.2])}},
+        best_loss=1.0,
+    )
+    checkpoint_path = tmp_path / "opt.pkl"
+    save_checkpoint(
+        str(checkpoint_path),
+        make_optimization_checkpoint(opt_result, opt_state),
+    )
+
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+        },
+        "data": {
+            "target_path": str(target_path),
+            "mask_path": str(tmp_path / "mask.npy"),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {"enabled": False},
+        "variational": {
+            "enabled": True,
+            "resume_checkpoint": str(checkpoint_path),
+        },
+        "predictive": {"enabled": False},
+    }
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    try:
+        run_ifu_experiment(cfg, pipeline_factory=pipeline_factory)
+    except ValueError as exc:
+        assert "variational.resume_checkpoint" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for mismatched checkpoint kind")


### PR DESCRIPTION
## Summary
- add `rubix.inference.experiment` for config-driven production IFU runs
- support deterministic/stochastic mode, objective config wiring, staged optimize/VI execution
- add chunked checkpoint cadence and stage resume support with failure metadata
- add `scripts/run_ifu_science_experiment.py` CLI and template config
- add guardrail benchmark script and real-data runbook updates
- add tests for config normalization, stage execution, output persistence, and resume-kind validation

## Validation
- pre-commit run on changed files
- compileall on new module/script/tests

## Notes
- pytest remains flaky/hanging in this sandbox due local JAX backend/runtime behavior; unit tests are included and lint/style gates pass.
