### PR TITLE
feat(inference): add IFU input validator and smoke-only dry-run mode

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -348,18 +348,32 @@ Real Data Runbook
    ``target``, optional ``mask``, optional ``weights``, optional ``sigma`` or
    ``inv_variance``.
 2. Copy and edit
-   ``rubix/config/inference_experiment_template.yml``:
+   ``rubix/config/inference_experiment_realdata_scaffold.yml``:
    set ``run.rubix_config_path``, ``data.*_path``, and stage hyperparameters.
-3. Run deterministic fitting first:
+3. Validate shapes and values before expensive runs:
+
+   .. code-block:: bash
+
+      python scripts/validate_ifu_experiment_inputs.py \
+        --config rubix/config/inference_experiment_realdata_scaffold.yml
+
+4. Run smoke-only dry-run first (set ``run.smoke_only: true``):
 
    .. code-block:: bash
 
       python scripts/run_ifu_science_experiment.py \
-        --config rubix/config/inference_experiment_template.yml
+        --config rubix/config/inference_experiment_realdata_scaffold.yml
 
-4. If interrupted, resume from latest stage checkpoint by setting
+5. Then disable smoke mode and run deterministic fitting:
+
+   .. code-block:: bash
+
+      python scripts/run_ifu_science_experiment.py \
+        --config rubix/config/inference_experiment_realdata_scaffold.yml
+
+6. If interrupted, resume from latest stage checkpoint by setting
    ``optimization.resume_checkpoint`` or ``variational.resume_checkpoint``.
-5. Inspect outputs in ``run.output_dir``:
+7. Inspect outputs in ``run.output_dir``:
    ``summary.json``, ``predictive_summary.npz``, ``residual_products.npz``.
 
 Benchmarking Full-IFU Optimization

--- a/rubix/config/inference_experiment_realdata_scaffold.yml
+++ b/rubix/config/inference_experiment_realdata_scaffold.yml
@@ -1,40 +1,34 @@
 run:
-  rubix_config_path: rubix/config/rubix_config.yml
+  rubix_config_path: path/to/your/rubix_user_config.yml
   mode: deterministic
-  smoke_only: false
+  smoke_only: true
   seed: 0
   noise_seed: 0
-  output_dir: outputs/ifu_science
-  checkpoint_dir: outputs/ifu_science/checkpoints
+  output_dir: outputs/ifu_realdata_smoke
+  checkpoint_dir: outputs/ifu_realdata_smoke/checkpoints
   params_init_overrides:
     stars:
       age: [1.0]
       metallicity: [0.01]
   objective:
-    kind: combined
-    terms:
-      - kind: gaussian_nll
-        inv_variance_key: inv_variance
-        mask_key: mask
-      - kind: huber
-        delta: 0.2
-        mask_key: mask
-        weight: 0.05
+    kind: gaussian_nll
+    inv_variance_key: inv_variance
+    mask_key: mask
 
 data:
-  target_path: data/target_cube.npy
+  target_path: path/to/target_cube.npy
   target_key:
-  mask_path: data/mask_cube.npy
+  mask_path: path/to/mask_cube.npy
   mask_key:
   weights_path:
   weights_key:
   sigma_path:
   sigma_key:
-  inv_variance_path: data/inv_variance_cube.npy
+  inv_variance_path: path/to/inv_variance_cube.npy
   inv_variance_key:
 
 optimization:
-  enabled: true
+  enabled: false
   learning_rate: 0.001
   max_steps: 500
   tol: 1.0e-6
@@ -43,7 +37,7 @@ optimization:
   resume_checkpoint:
 
 variational:
-  enabled: true
+  enabled: false
   learning_rate: 0.005
   max_steps: 500
   tol: 1.0e-6
@@ -57,5 +51,5 @@ variational:
   resume_checkpoint:
 
 predictive:
-  enabled: true
+  enabled: false
   num_draws: 16

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -20,6 +20,7 @@ from .experiment import (
     normalize_experiment_config,
     run_ifu_experiment,
     save_ifu_experiment_outputs,
+    validate_ifu_experiment_inputs,
 )
 from .losses import combine_loss_fns, huber_data_loss, masked_gaussian_nll
 from .modes import get_pipeline_name_for_mode, make_inference_pipeline
@@ -132,6 +133,7 @@ __all__ = [
     "save_checkpoint",
     "run_ifu_experiment",
     "save_ifu_experiment_outputs",
+    "validate_ifu_experiment_inputs",
     "value_and_grad",
     "run_synthetic_science_recipe",
     "save_science_recipe_outputs",

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -377,6 +377,21 @@ def validate_ifu_experiment_inputs(
     except Exception as exc:
         report["errors"].append(f"params_error: {exc}")
 
+    objective_cfg = cfg["run"].get("objective")
+    if isinstance(objective_cfg, Mapping):
+        try:
+            build_loss_from_config(
+                objective_config=objective_cfg,
+                tensors={
+                    "mask": mask,
+                    "weights": weights,
+                    "sigma": sigma,
+                    "inv_variance": inv_variance,
+                },
+            )
+        except Exception as exc:
+            report["errors"].append(f"objective_error: {exc}")
+
     report["ok"] = len(report["errors"]) == 0
     return report
 

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -11,6 +11,7 @@ import numpy as np
 from rubix.core.data import RubixData
 from rubix.utils import get_config, read_yaml
 
+from .api import forward
 from .checkpoint import (
     load_checkpoint,
     make_optimization_checkpoint,
@@ -205,6 +206,7 @@ def normalize_experiment_config(config: Mapping[str, Any]) -> dict[str, Any]:
         "run": {
             "rubix_config_path": rubix_config_path,
             "mode": mode,
+            "smoke_only": bool(run_cfg.get("smoke_only", False)),
             "seed": int(run_cfg.get("seed", 0)),
             "output_dir": run_cfg.get("output_dir", "outputs/ifu_science"),
             "checkpoint_dir": run_cfg.get("checkpoint_dir"),
@@ -264,6 +266,119 @@ def normalize_experiment_config(config: Mapping[str, Any]) -> dict[str, Any]:
             normalized[stage_name]["checkpoint_interval_steps"] = interval_int
 
     return normalized
+
+
+def validate_ifu_experiment_inputs(
+    config: ExperimentConfigInput,
+    pipeline_factory: PipelineFactory = make_inference_pipeline,
+) -> dict[str, Any]:
+    """Validate IFU experiment inputs and return a machine-readable report.
+
+    Validation covers config normalization, tensor loading, tensor shape/value
+    consistency, and default parameter initialization against prepared static
+    Rubix data.
+
+    Args:
+        config (ExperimentConfigInput): Mapping or YAML path following the
+            experiment schema consumed by :func:`normalize_experiment_config`.
+        pipeline_factory (PipelineFactory, optional): Pipeline builder used to
+            instantiate and prepare a Rubix pipeline. Defaults to
+            :func:`make_inference_pipeline`.
+
+    Returns:
+        dict[str, Any]: Validation report with keys ``ok``, ``errors``,
+        ``warnings``, ``config``, and ``shapes``.
+    """
+    report: dict[str, Any] = {
+        "ok": False,
+        "errors": [],
+        "warnings": [],
+        "config": None,
+        "shapes": {},
+    }
+
+    try:
+        raw_cfg = read_yaml(config) if isinstance(config, str) else dict(config)
+        cfg = normalize_experiment_config(raw_cfg)
+        report["config"] = cfg
+    except Exception as exc:  # pragma: no cover - exercised indirectly
+        report["errors"].append(f"config_error: {exc}")
+        return report
+
+    try:
+        prepared = _prepare_pipeline(
+            rubix_config_path=str(cfg["run"]["rubix_config_path"]),
+            mode=cfg["run"]["mode"],
+            pipeline_factory=pipeline_factory,
+        )
+    except Exception as exc:  # pragma: no cover - depends on runtime setup
+        report["errors"].append(f"pipeline_error: {exc}")
+        return report
+
+    try:
+        tensors = _resolve_data_tensors(cfg["data"])
+    except Exception as exc:
+        report["errors"].append(f"data_error: {exc}")
+        return report
+
+    target = tensors["target"]
+    mask = tensors["mask"]
+    weights = tensors["weights"]
+    sigma = tensors["sigma"]
+    inv_variance = tensors["inv_variance"]
+
+    report["shapes"] = {
+        "target": tuple(target.shape),
+        "mask": None if mask is None else tuple(mask.shape),
+        "weights": None if weights is None else tuple(weights.shape),
+        "sigma": None if sigma is None else tuple(sigma.shape),
+        "inv_variance": None if inv_variance is None else tuple(inv_variance.shape),
+    }
+
+    if target.ndim != 3:
+        report["errors"].append("target must be 3D")
+
+    if sigma is not None and inv_variance is not None:
+        report["errors"].append("only one of sigma or inv_variance may be provided")
+
+    if not bool(jnp.all(jnp.isfinite(target))):
+        report["errors"].append("target contains non-finite values")
+
+    for name, tensor in {
+        "mask": mask,
+        "weights": weights,
+        "sigma": sigma,
+        "inv_variance": inv_variance,
+    }.items():
+        if tensor is None:
+            continue
+        if tensor.shape != target.shape:
+            report["errors"].append(
+                f"{name} shape {tuple(tensor.shape)} does not match target shape {tuple(target.shape)}"
+            )
+        if not bool(jnp.all(jnp.isfinite(tensor))):
+            report["errors"].append(f"{name} contains non-finite values")
+
+    if mask is not None and not bool(jnp.all(mask >= 0)):
+        report["errors"].append("mask must be non-negative")
+
+    if weights is not None and not bool(jnp.all(weights >= 0)):
+        report["errors"].append("weights must be non-negative")
+
+    if sigma is not None and not bool(jnp.all(sigma > 0)):
+        report["errors"].append("sigma must be strictly positive")
+
+    if inv_variance is not None and not bool(jnp.all(inv_variance >= 0)):
+        report["errors"].append("inv_variance must be non-negative")
+
+    try:
+        params_init = _default_params_init(prepared.static_data)
+        _apply_params_overrides(params_init, cfg["run"]["params_init_overrides"])
+    except Exception as exc:
+        report["errors"].append(f"params_error: {exc}")
+
+    report["ok"] = len(report["errors"]) == 0
+    return report
 
 
 def _prepare_pipeline(
@@ -723,37 +838,45 @@ def run_ifu_experiment(
     if checkpoint_dir is not None:
         Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
 
-    opt_result, _, opt_status = _run_optimization_stage(
-        pipeline=prepared.pipeline,
-        params_init=params_init,
-        static_data=prepared.static_data,
-        target=target,
-        mask=mask,
-        weights=weights,
-        noise_key=noise_key,
-        objective_loss_fn=objective_loss_fn,
-        stage_cfg=cfg["optimization"],
-        checkpoint_dir=checkpoint_dir,
-    )
+    smoke_only = bool(run_cfg["smoke_only"])
 
-    vi_params_init = params_init
-    if opt_result is not None and opt_status.get("status") == "completed":
-        vi_params_init = opt_result.params
+    if smoke_only:
+        opt_result = None
+        vi_result = None
+        opt_status = {"status": "skipped", "reason": "smoke_only"}
+        vi_status = {"status": "skipped", "reason": "smoke_only"}
+    else:
+        opt_result, _, opt_status = _run_optimization_stage(
+            pipeline=prepared.pipeline,
+            params_init=params_init,
+            static_data=prepared.static_data,
+            target=target,
+            mask=mask,
+            weights=weights,
+            noise_key=noise_key,
+            objective_loss_fn=objective_loss_fn,
+            stage_cfg=cfg["optimization"],
+            checkpoint_dir=checkpoint_dir,
+        )
 
-    vi_result, _, vi_status = _run_variational_stage(
-        pipeline=prepared.pipeline,
-        params_init=vi_params_init,
-        static_data=prepared.static_data,
-        target=target,
-        sigma=sigma,
-        inv_variance=inv_variance,
-        mask=mask,
-        noise_key=noise_key,
-        objective_loss_fn=objective_loss_fn,
-        stage_cfg=cfg["variational"],
-        checkpoint_dir=checkpoint_dir,
-        seed=int(run_cfg["seed"]),
-    )
+        vi_params_init = params_init
+        if opt_result is not None and opt_status.get("status") == "completed":
+            vi_params_init = opt_result.params
+
+        vi_result, _, vi_status = _run_variational_stage(
+            pipeline=prepared.pipeline,
+            params_init=vi_params_init,
+            static_data=prepared.static_data,
+            target=target,
+            sigma=sigma,
+            inv_variance=inv_variance,
+            mask=mask,
+            noise_key=noise_key,
+            objective_loss_fn=objective_loss_fn,
+            stage_cfg=cfg["variational"],
+            checkpoint_dir=checkpoint_dir,
+            seed=int(run_cfg["seed"]),
+        )
 
     outputs: dict[str, Any] = {
         "config": cfg,
@@ -786,7 +909,29 @@ def run_ifu_experiment(
             "final_kl": float(vi_result.final_kl),
         }
 
-    if bool(cfg["predictive"]["enabled"]) and vi_result is not None:
+    if smoke_only:
+        smoke_prediction = forward(
+            pipeline=prepared.pipeline,
+            params=params_init,
+            static_data=prepared.static_data,
+            noise_key=noise_key,
+        )
+        residual_products = compute_residual_products(
+            prediction=smoke_prediction,
+            target=target,
+            sigma=sigma,
+            inv_variance=inv_variance,
+            mask=mask,
+        )
+        metrics = summarize_masked_metrics(
+            prediction=smoke_prediction,
+            target=target,
+            mask=mask,
+            loss_fn=objective_loss_fn,
+        )
+        outputs["residual_products"] = residual_products
+        outputs["metrics"] = metrics
+    elif bool(cfg["predictive"]["enabled"]) and vi_result is not None:
         predictive_samples = sample_posterior_predictive_cubes(
             pipeline=prepared.pipeline,
             posterior_mean_params=vi_result.posterior_mean_params,

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -925,6 +925,11 @@ def run_ifu_experiment(
         }
 
     if smoke_only:
+        if sigma is not None and inv_variance is not None:
+            raise ValueError(
+                "smoke_only: provide only one of data.sigma_path or"
+                " data.inv_variance_path, not both"
+            )
         smoke_prediction = forward(
             pipeline=prepared.pipeline,
             params=params_init,

--- a/scripts/run_ifu_science_experiment.py
+++ b/scripts/run_ifu_science_experiment.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 import argparse
+import json
 
-from rubix.inference.experiment import run_ifu_experiment, save_ifu_experiment_outputs
+from rubix.inference.experiment import (
+    run_ifu_experiment,
+    save_ifu_experiment_outputs,
+    validate_ifu_experiment_inputs,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -15,11 +20,23 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Override output directory from config.run.output_dir",
     )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Validate config/inputs only and exit without running inference.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
+    if args.validate_only:
+        report = validate_ifu_experiment_inputs(args.config)
+        print(json.dumps(report, indent=2))
+        if not report["ok"]:
+            raise SystemExit(1)
+        return
+
     outputs = run_ifu_experiment(args.config)
 
     output_dir = args.output_dir

--- a/scripts/validate_ifu_experiment_inputs.py
+++ b/scripts/validate_ifu_experiment_inputs.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import argparse
+import json
+
+from rubix.inference.experiment import validate_ifu_experiment_inputs
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate IFU experiment config and data tensors before expensive runs."
+    )
+    parser.add_argument("--config", type=str, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    report = validate_ifu_experiment_inputs(args.config)
+    print(json.dumps(report, indent=2))
+    if not report["ok"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -350,7 +350,7 @@ def test_validate_ifu_experiment_inputs_valid_objective_passes(tmp_path):
     assert report["errors"] == []
 
 
-def test_run_ifu_experiment_smoke_only_raises_on_both_sigma_and_inv_variance(tmp_path):
+def test_smoke_only_rejects_both_sigma_and_inv_variance(tmp_path):
     cube = np.ones((2, 2, 4), dtype=np.float32)
     target_path = tmp_path / "target.npy"
     np.save(target_path, cube)
@@ -386,6 +386,8 @@ def test_run_ifu_experiment_smoke_only_raises_on_both_sigma_and_inv_variance(tmp
     else:
         raise AssertionError("Expected ValueError when both sigma and inv_variance provided in smoke_only mode")
 
+
+def test_run_ifu_experiment_smoke_only_computes_metrics(tmp_path):
     cube = np.ones((2, 2, 4), dtype=np.float32)
     target = 1.5 * cube
     target_path = tmp_path / "target.npy"

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -251,6 +251,103 @@ def test_validate_ifu_experiment_inputs_detects_shape_mismatch(tmp_path):
     assert any("mask shape" in error for error in report["errors"])
 
 
+def test_validate_ifu_experiment_inputs_detects_bad_objective_kind(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
+
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+            "objective": {"kind": "unsupported_kind"},
+        },
+        "data": {
+            "target_path": str(target_path),
+            "mask_path": str(tmp_path / "mask.npy"),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {"enabled": False},
+        "variational": {"enabled": False},
+        "predictive": {"enabled": False},
+    }
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    report = validate_ifu_experiment_inputs(cfg, pipeline_factory=pipeline_factory)
+    assert report["ok"] is False
+    assert any("objective_error" in error for error in report["errors"])
+
+
+def test_validate_ifu_experiment_inputs_detects_missing_tensor_key(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
+
+    # The mask_key references "nonexistent_key" which is not in the tensors mapping
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+            "objective": {"kind": "mse", "mask_key": "nonexistent_key"},
+        },
+        "data": {
+            "target_path": str(target_path),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {"enabled": False},
+        "variational": {"enabled": False},
+        "predictive": {"enabled": False},
+    }
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    report = validate_ifu_experiment_inputs(cfg, pipeline_factory=pipeline_factory)
+    assert report["ok"] is False
+    assert any("objective_error" in error for error in report["errors"])
+
+
+def test_validate_ifu_experiment_inputs_valid_objective_passes(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
+
+    # Use mask_key pointing at the actual loaded mask tensor
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+            "objective": {"kind": "mse", "mask_key": "mask"},
+        },
+        "data": {
+            "target_path": str(target_path),
+            "mask_path": str(tmp_path / "mask.npy"),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {"enabled": False},
+        "variational": {"enabled": False},
+        "predictive": {"enabled": False},
+    }
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    report = validate_ifu_experiment_inputs(cfg, pipeline_factory=pipeline_factory)
+    assert report["ok"] is True
+    assert report["errors"] == []
+
+
 def test_run_ifu_experiment_smoke_only_computes_metrics(tmp_path):
     cube = np.ones((2, 2, 4), dtype=np.float32)
     target = 1.5 * cube

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -291,7 +291,8 @@ def test_validate_ifu_experiment_inputs_detects_missing_tensor_key(tmp_path):
     np.save(tmp_path / "ivar.npy", np.ones_like(cube))
     (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
 
-    # The mask_key references "nonexistent_key" which is not in the tensors mapping
+    # mask is loaded (so tensors["mask"] is present), but mask_key references a
+    # key that does not exist in the tensors mapping → objective_error expected
     cfg = {
         "run": {
             "rubix_config_path": str(tmp_path / "rubix_user.yml"),
@@ -300,6 +301,7 @@ def test_validate_ifu_experiment_inputs_detects_missing_tensor_key(tmp_path):
         },
         "data": {
             "target_path": str(target_path),
+            "mask_path": str(tmp_path / "mask.npy"),
             "inv_variance_path": str(tmp_path / "ivar.npy"),
         },
         "optimization": {"enabled": False},

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -350,7 +350,42 @@ def test_validate_ifu_experiment_inputs_valid_objective_passes(tmp_path):
     assert report["errors"] == []
 
 
-def test_run_ifu_experiment_smoke_only_computes_metrics(tmp_path):
+def test_run_ifu_experiment_smoke_only_raises_on_both_sigma_and_inv_variance(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "sigma.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
+
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+            "smoke_only": True,
+        },
+        "data": {
+            "target_path": str(target_path),
+            "sigma_path": str(tmp_path / "sigma.npy"),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {"enabled": False},
+        "variational": {"enabled": False},
+        "predictive": {"enabled": False},
+    }
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    try:
+        run_ifu_experiment(cfg, pipeline_factory=pipeline_factory)
+    except ValueError as exc:
+        assert "smoke_only" in str(exc)
+        assert "sigma" in str(exc)
+        assert "inv_variance" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError when both sigma and inv_variance provided in smoke_only mode")
+
     cube = np.ones((2, 2, 4), dtype=np.float32)
     target = 1.5 * cube
     target_path = tmp_path / "target.npy"

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -13,6 +13,7 @@ from rubix.inference.experiment import (
     normalize_experiment_config,
     run_ifu_experiment,
     save_ifu_experiment_outputs,
+    validate_ifu_experiment_inputs,
 )
 from rubix.inference.optimize import OptimizationResult, OptimizationState
 
@@ -209,3 +210,78 @@ def test_run_ifu_experiment_rejects_mismatched_resume_checkpoint_kind(tmp_path):
         assert "variational.resume_checkpoint" in str(exc)
     else:
         raise AssertionError("Expected ValueError for mismatched checkpoint kind")
+
+
+def test_validate_ifu_experiment_inputs_reports_ok(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    config_path = _write_config(tmp_path, str(target_path), str(tmp_path / "ckpt"))
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    report = validate_ifu_experiment_inputs(
+        str(config_path),
+        pipeline_factory=pipeline_factory,
+    )
+    assert report["ok"] is True
+    assert report["errors"] == []
+    assert tuple(report["shapes"]["target"]) == (2, 2, 4)
+
+
+def test_validate_ifu_experiment_inputs_detects_shape_mismatch(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones((2, 2, 5), dtype=np.float32))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    config_path = _write_config(tmp_path, str(target_path), str(tmp_path / "ckpt"))
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    report = validate_ifu_experiment_inputs(
+        str(config_path),
+        pipeline_factory=pipeline_factory,
+    )
+    assert report["ok"] is False
+    assert any("mask shape" in error for error in report["errors"])
+
+
+def test_run_ifu_experiment_smoke_only_computes_metrics(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target = 1.5 * cube
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, target)
+    np.save(tmp_path / "mask.npy", np.ones_like(target))
+    np.save(tmp_path / "ivar.npy", np.ones_like(target))
+
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+            "smoke_only": True,
+        },
+        "data": {
+            "target_path": str(target_path),
+            "mask_path": str(tmp_path / "mask.npy"),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {"enabled": False},
+        "variational": {"enabled": False},
+        "predictive": {"enabled": False},
+    }
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    outputs = run_ifu_experiment(cfg, pipeline_factory=pipeline_factory)
+    assert outputs["stages"]["optimization"]["reason"] == "smoke_only"
+    assert outputs["stages"]["variational"]["reason"] == "smoke_only"
+    assert outputs["predictive_summary"] is None
+    assert outputs["metrics"] is not None
+    assert outputs["residual_products"] is not None


### PR DESCRIPTION
## Summary
- add `validate_ifu_experiment_inputs` to validate config, tensor loading, shape consistency, value constraints, and default parameter init
- add smoke-only execution mode (`run.smoke_only`) to support fast dry-runs without optimization/VI
- add `--validate-only` to `scripts/run_ifu_science_experiment.py`
- add dedicated validator CLI: `scripts/validate_ifu_experiment_inputs.py`
- add real-data scaffold config: `rubix/config/inference_experiment_realdata_scaffold.yml`
- extend docs runbook with validate -> smoke -> full-run sequence
- add unit tests for validator success/failure and smoke-only outputs

## Validation
- pre-commit run on changed files
- compileall on updated inference/scripts/tests

## Notes
- pytest execution still intermittently hangs in this sandbox JAX runtime, so lint/doc/style and compile checks were used for gating here.
