### PR TITLE
feat(inference): add checkpoint policy defaults and run metadata artifacts

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -336,8 +336,10 @@ The template supports:
 
 - deterministic or stochastic mode selection
 - runtime objective selection via ``run.objective``
-- chunked optimization/VI with stage checkpoints
+- standard checkpoint cadence and optional auto-resume from latest stage checkpoint
 - posterior predictive output products and masked science metrics
+- run metadata in ``summary.json`` (timestamps, duration, git SHA, config hash)
+- failure artifact export in ``failure_report.json`` when a stage fails
 
 
 Real Data Runbook
@@ -372,7 +374,8 @@ Real Data Runbook
         --config rubix/config/inference_experiment_realdata_scaffold.yml
 
 6. If interrupted, resume from latest stage checkpoint by setting
-   ``optimization.resume_checkpoint`` or ``variational.resume_checkpoint``.
+   ``optimization.resume_checkpoint`` or ``variational.resume_checkpoint`` to
+   ``latest`` (or set ``run.auto_resume_latest: true``).
 7. Inspect outputs in ``run.output_dir``:
    ``summary.json``, ``predictive_summary.npz``, ``residual_products.npz``.
 

--- a/rubix/config/inference_experiment_realdata_scaffold.yml
+++ b/rubix/config/inference_experiment_realdata_scaffold.yml
@@ -2,6 +2,9 @@ run:
   rubix_config_path: path/to/your/rubix_user_config.yml
   mode: deterministic
   smoke_only: true
+  auto_resume_latest: true
+  fail_on_stage_failure: false
+  checkpoint_policy: standard
   seed: 0
   noise_seed: 0
   output_dir: outputs/ifu_realdata_smoke
@@ -34,7 +37,7 @@ optimization:
   tol: 1.0e-6
   normalize_loss: true
   checkpoint_interval_steps: 100
-  resume_checkpoint:
+  resume_checkpoint: latest
 
 variational:
   enabled: false
@@ -48,7 +51,7 @@ variational:
   huber_delta: 0.2
   huber_weight: 0.0
   checkpoint_interval_steps: 100
-  resume_checkpoint:
+  resume_checkpoint: latest
 
 predictive:
   enabled: false

--- a/rubix/config/inference_experiment_realdata_scaffold.yml
+++ b/rubix/config/inference_experiment_realdata_scaffold.yml
@@ -2,7 +2,7 @@ run:
   rubix_config_path: path/to/your/rubix_user_config.yml
   mode: deterministic
   smoke_only: true
-  auto_resume_latest: true
+  auto_resume_latest: false
   fail_on_stage_failure: false
   checkpoint_policy: standard
   seed: 0

--- a/rubix/config/inference_experiment_template.yml
+++ b/rubix/config/inference_experiment_template.yml
@@ -42,7 +42,7 @@ optimization:
   max_steps: 500
   tol: 1.0e-6
   normalize_loss: true
-  checkpoint_interval_steps: 100
+  checkpoint_interval_steps:  # null → uses policy-derived default; set a positive integer to override
   resume_checkpoint:  # explicit path or "latest"
 
 variational:
@@ -56,7 +56,7 @@ variational:
   normalize_loss: true
   huber_delta: 0.2
   huber_weight: 0.0
-  checkpoint_interval_steps: 100
+  checkpoint_interval_steps:  # null → uses policy-derived default; set a positive integer to override
   resume_checkpoint:  # explicit path or "latest"
 
 predictive:

--- a/rubix/config/inference_experiment_template.yml
+++ b/rubix/config/inference_experiment_template.yml
@@ -2,6 +2,9 @@ run:
   rubix_config_path: rubix/config/rubix_config.yml
   mode: deterministic
   smoke_only: false
+  auto_resume_latest: false
+  fail_on_stage_failure: false
+  checkpoint_policy: standard
   seed: 0
   noise_seed: 0
   output_dir: outputs/ifu_science
@@ -40,7 +43,7 @@ optimization:
   tol: 1.0e-6
   normalize_loss: true
   checkpoint_interval_steps: 100
-  resume_checkpoint:
+  resume_checkpoint:  # explicit path or "latest"
 
 variational:
   enabled: true
@@ -54,7 +57,7 @@ variational:
   huber_delta: 0.2
   huber_weight: 0.0
   checkpoint_interval_steps: 100
-  resume_checkpoint:
+  resume_checkpoint:  # explicit path or "latest"
 
 predictive:
   enabled: true

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import subprocess
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Union
 
@@ -168,6 +172,74 @@ def _is_finite_scalar(value: float) -> bool:
     return bool(np.isfinite(value))
 
 
+def _utc_now_iso() -> str:
+    """Return current UTC timestamp in ISO-8601 format."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _stable_config_hash(config: Mapping[str, Any]) -> str:
+    """Return stable SHA256 hash for a normalized experiment config."""
+    json_text = json.dumps(_to_jsonable(dict(config)), sort_keys=True)
+    return hashlib.sha256(json_text.encode("utf-8")).hexdigest()
+
+
+def _get_git_commit_sha() -> Optional[str]:
+    """Return current git commit SHA if available, else ``None``."""
+    try:
+        output = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except Exception:  # pragma: no cover - environment-dependent
+        return None
+    value = output.strip()
+    return value if value else None
+
+
+def _default_checkpoint_interval(max_steps: int) -> int:
+    """Return standard checkpoint cadence for a stage."""
+    return max(1, min(200, max_steps // 5 if max_steps >= 5 else max_steps))
+
+
+def _resolve_resume_checkpoint_path(
+    resume_checkpoint: Optional[str],
+    checkpoint_dir: Optional[str],
+    stage: str,
+) -> Optional[str]:
+    """Resolve explicit or ``latest`` stage checkpoint path.
+
+    Args:
+        resume_checkpoint (Optional[str]): Configured checkpoint path or
+            ``'latest'`` sentinel.
+        checkpoint_dir (Optional[str]): Stage checkpoint directory.
+        stage (str): Stage name.
+
+    Raises:
+        ValueError: If ``resume_checkpoint`` is ``'latest'`` but
+            ``checkpoint_dir`` is unavailable.
+
+    Returns:
+        Optional[str]: Resolved checkpoint path if available.
+    """
+    if not isinstance(resume_checkpoint, str) or len(resume_checkpoint) == 0:
+        return None
+
+    if resume_checkpoint != "latest":
+        return resume_checkpoint
+
+    if checkpoint_dir is None:
+        raise ValueError(
+            f"{stage}.resume_checkpoint is 'latest' but run.checkpoint_dir is not set"
+        )
+
+    pattern = f"{stage}_chunk_*.pkl"
+    candidates = sorted(Path(checkpoint_dir).glob(pattern))
+    if len(candidates) == 0:
+        return None
+    return str(candidates[-1])
+
+
 def normalize_experiment_config(config: Mapping[str, Any]) -> dict[str, Any]:
     """Validate and normalize a production IFU experiment config mapping.
 
@@ -207,6 +279,9 @@ def normalize_experiment_config(config: Mapping[str, Any]) -> dict[str, Any]:
             "rubix_config_path": rubix_config_path,
             "mode": mode,
             "smoke_only": bool(run_cfg.get("smoke_only", False)),
+            "auto_resume_latest": bool(run_cfg.get("auto_resume_latest", False)),
+            "fail_on_stage_failure": bool(run_cfg.get("fail_on_stage_failure", False)),
+            "checkpoint_policy": str(run_cfg.get("checkpoint_policy", "standard")),
             "seed": int(run_cfg.get("seed", 0)),
             "output_dir": run_cfg.get("output_dir", "outputs/ifu_science"),
             "checkpoint_dir": run_cfg.get("checkpoint_dir"),
@@ -264,6 +339,13 @@ def normalize_experiment_config(config: Mapping[str, Any]) -> dict[str, Any]:
                     f"{stage_name}.checkpoint_interval_steps must be positive if provided"
                 )
             normalized[stage_name]["checkpoint_interval_steps"] = interval_int
+        elif normalized["run"]["checkpoint_policy"] == "standard":
+            normalized[stage_name]["checkpoint_interval_steps"] = (
+                _default_checkpoint_interval(int(normalized[stage_name]["max_steps"]))
+            )
+
+    if normalized["run"]["checkpoint_policy"] not in {"standard", "manual"}:
+        raise ValueError("run.checkpoint_policy must be 'standard' or 'manual'")
 
     return normalized
 
@@ -479,6 +561,7 @@ def _run_optimization_stage(
     objective_loss_fn: Optional[Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]],
     stage_cfg: Mapping[str, Any],
     checkpoint_dir: Optional[str],
+    auto_resume_latest: bool = False,
 ) -> tuple[Optional[OptimizationResult], Optional[OptimizationState], dict[str, Any]]:
     """Run optimization stage with optional checkpoint cadence and resume.
 
@@ -494,6 +577,9 @@ def _run_optimization_stage(
             Optional custom objective callable.
         stage_cfg (Mapping[str, Any]): Normalized optimization config.
         checkpoint_dir (Optional[str]): Optional checkpoint output directory.
+        auto_resume_latest (bool, optional): If ``True`` and no explicit
+            resume checkpoint is provided, attempt to resume from the latest
+            stage checkpoint in ``checkpoint_dir``. Defaults to ``False``.
 
     Raises:
         ValueError: If ``resume_checkpoint`` exists but is not an optimization
@@ -506,6 +592,7 @@ def _run_optimization_stage(
     if not stage_cfg["enabled"]:
         return None, None, {"status": "skipped", "reason": "disabled"}
 
+    stage_t0 = time.perf_counter()
     remaining = int(stage_cfg["max_steps"])
     interval = stage_cfg["checkpoint_interval_steps"]
     if interval is None:
@@ -520,9 +607,16 @@ def _run_optimization_stage(
     chunk_idx = 0
     steps_completed = 0
 
-    resume_checkpoint = stage_cfg.get("resume_checkpoint")
-    if isinstance(resume_checkpoint, str) and len(resume_checkpoint) > 0:
-        payload = load_checkpoint(resume_checkpoint)
+    resume_value = stage_cfg.get("resume_checkpoint")
+    if auto_resume_latest and not resume_value and checkpoint_dir is not None:
+        resume_value = "latest"
+    resolved_resume = _resolve_resume_checkpoint_path(
+        resume_checkpoint=resume_value,
+        checkpoint_dir=checkpoint_dir,
+        stage="optimization",
+    )
+    if resolved_resume is not None:
+        payload = load_checkpoint(resolved_resume)
         if payload.get("kind") != "optimization":
             raise ValueError(
                 "optimization.resume_checkpoint must reference optimization"
@@ -615,6 +709,8 @@ def _run_optimization_stage(
             "converged": bool(latest_result.converged),
             "steps_completed": steps_completed,
             "final_loss": float(latest_result.final_loss),
+            "duration_s": float(time.perf_counter() - stage_t0),
+            "resume_checkpoint_used": resolved_resume,
         },
     )
 
@@ -632,6 +728,7 @@ def _run_variational_stage(
     stage_cfg: Mapping[str, Any],
     checkpoint_dir: Optional[str],
     seed: int,
+    auto_resume_latest: bool = False,
 ) -> tuple[Optional[VariationalResult], Optional[VariationalState], dict[str, Any]]:
     """Run VI stage with optional checkpoint cadence and resume.
 
@@ -649,6 +746,9 @@ def _run_variational_stage(
         stage_cfg (Mapping[str, Any]): Normalized variational config.
         checkpoint_dir (Optional[str]): Optional checkpoint output directory.
         seed (int): Random seed.
+        auto_resume_latest (bool, optional): If ``True`` and no explicit
+            resume checkpoint is provided, attempt to resume from the latest
+            stage checkpoint in ``checkpoint_dir``. Defaults to ``False``.
 
     Raises:
         ValueError: If ``resume_checkpoint`` exists but is not a variational
@@ -661,6 +761,7 @@ def _run_variational_stage(
     if not stage_cfg["enabled"]:
         return None, None, {"status": "skipped", "reason": "disabled"}
 
+    stage_t0 = time.perf_counter()
     remaining = int(stage_cfg["max_steps"])
     interval = stage_cfg["checkpoint_interval_steps"]
     if interval is None:
@@ -675,9 +776,16 @@ def _run_variational_stage(
     chunk_idx = 0
     steps_completed = 0
 
-    resume_checkpoint = stage_cfg.get("resume_checkpoint")
-    if isinstance(resume_checkpoint, str) and len(resume_checkpoint) > 0:
-        payload = load_checkpoint(resume_checkpoint)
+    resume_value = stage_cfg.get("resume_checkpoint")
+    if auto_resume_latest and not resume_value and checkpoint_dir is not None:
+        resume_value = "latest"
+    resolved_resume = _resolve_resume_checkpoint_path(
+        resume_checkpoint=resume_value,
+        checkpoint_dir=checkpoint_dir,
+        stage="variational",
+    )
+    if resolved_resume is not None:
+        payload = load_checkpoint(resolved_resume)
         if payload.get("kind") != "variational":
             raise ValueError("variational.resume_checkpoint must reference variational")
         latest_result = payload["result"]
@@ -782,6 +890,8 @@ def _run_variational_stage(
             "converged": bool(latest_result.converged),
             "steps_completed": steps_completed,
             "final_objective": float(latest_result.final_objective),
+            "duration_s": float(time.perf_counter() - stage_t0),
+            "resume_checkpoint_used": resolved_resume,
         },
     )
 
@@ -803,10 +913,18 @@ def run_ifu_experiment(
             instantiate and prepare a Rubix pipeline. Defaults to
             :func:`make_inference_pipeline`.
 
+    Raises:
+        ValueError: If incompatible smoke-only uncertainty settings are
+            provided (both ``sigma`` and ``inv_variance``).
+        RuntimeError: If stage failures occur and
+            ``run.fail_on_stage_failure`` is enabled.
+
     Returns:
         dict[str, Any]: Structured outputs including stage summaries, optional
         predictive outputs, residual maps, and scalar metrics.
     """
+    run_started_at = _utc_now_iso()
+    run_t0 = time.perf_counter()
     raw_cfg = read_yaml(config) if isinstance(config, str) else dict(config)
     cfg = normalize_experiment_config(raw_cfg)
 
@@ -854,6 +972,7 @@ def run_ifu_experiment(
         Path(checkpoint_dir).mkdir(parents=True, exist_ok=True)
 
     smoke_only = bool(run_cfg["smoke_only"])
+    auto_resume_latest = bool(run_cfg["auto_resume_latest"])
 
     if smoke_only:
         opt_result = None
@@ -872,6 +991,7 @@ def run_ifu_experiment(
             objective_loss_fn=objective_loss_fn,
             stage_cfg=cfg["optimization"],
             checkpoint_dir=checkpoint_dir,
+            auto_resume_latest=auto_resume_latest,
         )
 
         vi_params_init = params_init
@@ -891,14 +1011,32 @@ def run_ifu_experiment(
             stage_cfg=cfg["variational"],
             checkpoint_dir=checkpoint_dir,
             seed=int(run_cfg["seed"]),
+            auto_resume_latest=auto_resume_latest,
         )
+
+    failed_stages = {
+        name: stage
+        for name, stage in {
+            "optimization": opt_status,
+            "variational": vi_status,
+        }.items()
+        if stage.get("status") == "failed"
+    }
 
     outputs: dict[str, Any] = {
         "config": cfg,
+        "run_metadata": {
+            "started_at_utc": run_started_at,
+            "finished_at_utc": None,
+            "run_duration_s": None,
+            "git_commit_sha": _get_git_commit_sha(),
+            "config_hash_sha256": _stable_config_hash(cfg),
+        },
         "stages": {
             "optimization": opt_status,
             "variational": vi_status,
         },
+        "failure_artifacts": None,
         "optimization": None,
         "variational": None,
         "predictive_summary": None,
@@ -980,6 +1118,23 @@ def run_ifu_experiment(
         outputs["residual_products"] = residual_products
         outputs["metrics"] = metrics
 
+    if len(failed_stages) > 0:
+        outputs["failure_artifacts"] = {
+            "failed_stages": failed_stages,
+            "guidance": (
+                "Inspect stage status reasons and resume from checkpoints after "
+                "adjusting learning rate / objective settings."
+            ),
+        }
+
+    outputs["run_metadata"]["finished_at_utc"] = _utc_now_iso()
+    outputs["run_metadata"]["run_duration_s"] = float(time.perf_counter() - run_t0)
+
+    if len(failed_stages) > 0 and bool(run_cfg["fail_on_stage_failure"]):
+        raise RuntimeError(
+            f"IFU experiment failed stages: {sorted(failed_stages.keys())}"
+        )
+
     return outputs
 
 
@@ -996,6 +1151,7 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
 
     summary = {
         "config": outputs.get("config"),
+        "run_metadata": outputs.get("run_metadata"),
         "stages": outputs.get("stages"),
         "optimization": outputs.get("optimization"),
         "variational": outputs.get("variational"),
@@ -1018,4 +1174,11 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
         np.savez(
             out_dir / "residual_products.npz",
             **{k: np.asarray(v) for k, v in residual_products.items()},
+        )
+
+    failure_artifacts = outputs.get("failure_artifacts")
+    if isinstance(failure_artifacts, Mapping):
+        (out_dir / "failure_report.json").write_text(
+            json.dumps(_to_jsonable(dict(failure_artifacts)), indent=2),
+            encoding="utf-8",
         )

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -281,7 +281,9 @@ def normalize_experiment_config(config: Mapping[str, Any]) -> dict[str, Any]:
             "smoke_only": bool(run_cfg.get("smoke_only", False)),
             "auto_resume_latest": bool(run_cfg.get("auto_resume_latest", False)),
             "fail_on_stage_failure": bool(run_cfg.get("fail_on_stage_failure", False)),
-            "checkpoint_policy": str(run_cfg.get("checkpoint_policy", "standard")),
+            "checkpoint_policy": (
+                lambda v: v.strip().lower() if isinstance(v, str) and v.strip() else "standard"
+            )(run_cfg.get("checkpoint_policy")),
             "seed": int(run_cfg.get("seed", 0)),
             "output_dir": run_cfg.get("output_dir", "outputs/ifu_science"),
             "checkpoint_dir": run_cfg.get("checkpoint_dir"),
@@ -722,6 +724,8 @@ def _run_optimization_stage(
                     "status": "failed",
                     "reason": "non_finite_final_loss",
                     "steps_completed": steps_completed,
+                    "duration_s": float(time.perf_counter() - stage_t0),
+                    "resume_checkpoint_used": resolved_resume,
                 },
             )
 
@@ -912,6 +916,8 @@ def _run_variational_stage(
                     "status": "failed",
                     "reason": "non_finite_final_objective",
                     "steps_completed": steps_completed,
+                    "duration_s": float(time.perf_counter() - stage_t0),
+                    "resume_checkpoint_used": resolved_resume,
                 },
             )
 

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -550,6 +550,27 @@ def _checkpoint_path(directory: str, stage: str, chunk_idx: int) -> str:
     return str(Path(directory) / f"{stage}_chunk_{chunk_idx:04d}.pkl")
 
 
+def _chunk_idx_from_path(path: str) -> int:
+    """Extract the chunk index encoded in a checkpoint filename.
+
+    Checkpoint filenames follow the pattern ``{stage}_chunk_{idx:04d}.pkl``.
+    If the index cannot be parsed, 0 is returned so the caller's ``+= 1``
+    logic still produces a safe (though non-contiguous) index.
+
+    Args:
+        path (str): Checkpoint file path.
+
+    Returns:
+        int: Parsed chunk index, or 0 on parse failure.
+    """
+    stem = Path(path).stem  # e.g. "optimization_chunk_0003"
+    parts = stem.rsplit("_", 1)
+    try:
+        return int(parts[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
 def _run_optimization_stage(
     pipeline: Any,
     params_init: Mapping[str, Mapping[str, Any]],
@@ -625,8 +646,17 @@ def _run_optimization_stage(
         latest_state = payload["state"]
         state_init = latest_state
         current_params = latest_result.params
-        steps_completed = int(latest_result.steps_run)
+        # Use cumulative steps_completed from checkpoint metadata; fall back to
+        # per-chunk steps_run only if metadata is absent (legacy checkpoints).
+        steps_completed = int(
+            payload.get("metadata", {}).get(
+                "steps_completed", latest_result.steps_run
+            )
+        )
         remaining = max(0, remaining - steps_completed)
+        # Restore chunk_idx from the resumed filename so subsequent saves do
+        # not overwrite earlier chunk files.
+        chunk_idx = _chunk_idx_from_path(resolved_resume)
 
     while remaining > 0:
         run_steps = min(remaining, interval)
@@ -792,8 +822,17 @@ def _run_variational_stage(
         latest_state = payload["state"]
         state_init = latest_state
         current_params = latest_result.posterior_mean_constrained_params
-        steps_completed = int(latest_result.steps_run)
+        # Use cumulative steps_completed from checkpoint metadata; fall back to
+        # per-chunk steps_run only if metadata is absent (legacy checkpoints).
+        steps_completed = int(
+            payload.get("metadata", {}).get(
+                "steps_completed", latest_result.steps_run
+            )
+        )
         remaining = max(0, remaining - steps_completed)
+        # Restore chunk_idx from the resumed filename so subsequent saves do
+        # not overwrite earlier chunk files.
+        chunk_idx = _chunk_idx_from_path(resolved_resume)
 
     while remaining > 0:
         run_steps = min(remaining, interval)

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -46,6 +46,13 @@ class PreparedSyntheticPipeline:
         return scale * self.template
 
 
+class PreparedNaNPipeline(PreparedSyntheticPipeline):
+    """Synthetic pipeline that returns NaNs to force stage failure artifacts."""
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        return jnp.full_like(self.template, jnp.nan)
+
+
 def _write_config(tmp_path: Path, target_path: str, checkpoint_dir: str) -> Path:
     cfg = {
         "run": {
@@ -101,6 +108,9 @@ def test_normalize_experiment_config_applies_defaults():
     assert normalized["optimization"]["enabled"] is True
     assert normalized["variational"]["enabled"] is True
     assert normalized["predictive"]["num_draws"] == 16
+    assert normalized["optimization"]["checkpoint_interval_steps"] == 80
+    assert normalized["variational"]["checkpoint_interval_steps"] == 80
+    assert normalized["run"]["checkpoint_policy"] == "standard"
 
 
 def test_run_ifu_experiment_and_save_outputs(tmp_path):
@@ -125,6 +135,10 @@ def test_run_ifu_experiment_and_save_outputs(tmp_path):
 
     assert outputs["stages"]["optimization"]["status"] == "completed"
     assert outputs["stages"]["variational"]["status"] == "completed"
+    assert outputs["run_metadata"]["config_hash_sha256"] is not None
+    assert outputs["run_metadata"]["started_at_utc"] is not None
+    assert outputs["run_metadata"]["finished_at_utc"] is not None
+    assert outputs["run_metadata"]["run_duration_s"] is not None
     assert outputs["metrics"]["mse"] >= 0.0
     assert outputs["predictive_summary"]["mean"].shape == (2, 2, 4)
 
@@ -135,6 +149,42 @@ def test_run_ifu_experiment_and_save_outputs(tmp_path):
     assert (tmp_path / "saved" / "summary.json").exists()
     assert (tmp_path / "saved" / "predictive_summary.npz").exists()
     assert (tmp_path / "saved" / "residual_products.npz").exists()
+
+
+def test_run_ifu_experiment_generates_failure_artifacts(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
+
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+            "checkpoint_dir": str(tmp_path / "ckpt"),
+        },
+        "data": {
+            "target_path": str(target_path),
+            "mask_path": str(tmp_path / "mask.npy"),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {"enabled": True, "max_steps": 3, "learning_rate": 0.1},
+        "variational": {"enabled": False},
+        "predictive": {"enabled": False},
+    }
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedNaNPipeline(jnp.asarray(cube))
+
+    outputs = run_ifu_experiment(cfg, pipeline_factory=pipeline_factory)
+    assert outputs["stages"]["optimization"]["status"] == "failed"
+    assert outputs["failure_artifacts"] is not None
+    assert "optimization" in outputs["failure_artifacts"]["failed_stages"]
+
+    save_ifu_experiment_outputs(outputs, str(tmp_path / "saved"))
+    assert (tmp_path / "saved" / "failure_report.json").exists()
 
 
 def test_normalize_experiment_config_rejects_invalid_checkpoint_interval():
@@ -384,7 +434,9 @@ def test_smoke_only_rejects_both_sigma_and_inv_variance(tmp_path):
         assert "sigma" in str(exc)
         assert "inv_variance" in str(exc)
     else:
-        raise AssertionError("Expected ValueError when both sigma and inv_variance provided in smoke_only mode")
+        raise AssertionError(
+            "Expected ValueError when both sigma and inv_variance provided in smoke_only mode"
+        )
 
 
 def test_run_ifu_experiment_smoke_only_computes_metrics(tmp_path):


### PR DESCRIPTION
## Summary
- add standard checkpoint policy defaults (`run.checkpoint_policy: standard`) for optimize/VI stages
- add auto-resume support from latest stage checkpoint (`run.auto_resume_latest` or explicit `resume_checkpoint: latest`)
- include run metadata in outputs and `summary.json` (UTC timestamps, duration, git SHA, config hash)
- include stage duration and resolved resume checkpoint in stage status
- persist failure artifacts in `failure_report.json` when stages fail
- add tests for default checkpoint intervals, run metadata, and failure artifact emission
- document new checkpoint/resume policy and metadata/failure outputs

## Validation
- pre-commit run on changed files
- python -m compileall on updated module/tests

## Notes
- pytest execution remains flaky/hanging in this sandbox JAX runtime; lint/doc/style and compile checks were used for gating here.
