### PR TITLE
feat(inference): add standardized science outputs and report generator

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -338,6 +338,7 @@ The template supports:
 - runtime objective selection via ``run.objective``
 - chunked optimization/VI with stage checkpoints
 - posterior predictive output products and masked science metrics
+- standardized ``science_products.npz`` and ``science_metrics.csv`` artifacts
 
 
 Real Data Runbook
@@ -374,7 +375,15 @@ Real Data Runbook
 6. If interrupted, resume from latest stage checkpoint by setting
    ``optimization.resume_checkpoint`` or ``variational.resume_checkpoint``.
 7. Inspect outputs in ``run.output_dir``:
-   ``summary.json``, ``predictive_summary.npz``, ``residual_products.npz``.
+   ``summary.json``, ``predictive_summary.npz``, ``residual_products.npz``,
+   ``science_products.npz``, and ``science_metrics.csv``.
+
+8. Generate a compact report for quick review:
+
+   .. code-block:: bash
+
+      python scripts/generate_ifu_experiment_report.py \
+        --output-dir outputs/ifu_realdata_smoke
 
 Benchmarking Full-IFU Optimization
 ----------------------------------

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -17,6 +17,7 @@ from .checkpoint import (
     save_checkpoint,
 )
 from .experiment import (
+    generate_ifu_experiment_report,
     normalize_experiment_config,
     run_ifu_experiment,
     save_ifu_experiment_outputs,
@@ -93,6 +94,7 @@ __all__ = [
     "load_checkpoint",
     "make_optimization_checkpoint",
     "make_variational_checkpoint",
+    "generate_ifu_experiment_report",
     "normalize_experiment_config",
     "build_age_metallicity_transforms",
     "build_ifu_cube_loss",

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1089,7 +1089,6 @@ def generate_ifu_experiment_report(output_dir: str) -> dict[str, Any]:
             "optimization": summary.get("optimization"),
             "variational": summary.get("variational"),
             "metrics": summary.get("metrics"),
-            "run_metadata": summary.get("run_metadata"),
         },
         "artifacts": {},
     }

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Union
@@ -803,6 +804,10 @@ def run_ifu_experiment(
             instantiate and prepare a Rubix pipeline. Defaults to
             :func:`make_inference_pipeline`.
 
+    Raises:
+        ValueError: If ``smoke_only`` mode is configured with both ``sigma``
+            and ``inv_variance`` tensors.
+
     Returns:
         dict[str, Any]: Structured outputs including stage summaries, optional
         predictive outputs, residual maps, and scalar metrics.
@@ -1019,3 +1024,91 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
             out_dir / "residual_products.npz",
             **{k: np.asarray(v) for k, v in residual_products.items()},
         )
+
+    science_products: dict[str, np.ndarray] = {}
+    if isinstance(predictive_summary, Mapping):
+        predictive_rename = {
+            "mean": "posterior_mean_cube",
+            "std": "posterior_std_cube",
+            "p16": "posterior_p16_cube",
+            "p50": "posterior_p50_cube",
+            "p84": "posterior_p84_cube",
+        }
+        for old_key, new_key in predictive_rename.items():
+            if old_key in predictive_summary:
+                science_products[new_key] = np.asarray(predictive_summary[old_key])
+
+    if isinstance(residual_products, Mapping):
+        residual_rename = {
+            "residual": "residual_cube",
+            "abs_residual": "abs_residual_cube",
+            "chi2": "chi2_cube",
+            "masked_residual": "masked_residual_cube",
+            "masked_chi2": "masked_chi2_cube",
+        }
+        for old_key, new_key in residual_rename.items():
+            if old_key in residual_products:
+                science_products[new_key] = np.asarray(residual_products[old_key])
+
+    if len(science_products) > 0:
+        np.savez(out_dir / "science_products.npz", **science_products)
+
+    metrics = outputs.get("metrics")
+    if isinstance(metrics, Mapping):
+        with (out_dir / "science_metrics.csv").open(
+            "w", newline="", encoding="utf-8"
+        ) as handle:
+            writer = csv.writer(handle)
+            writer.writerow(["metric", "value"])
+            for key in sorted(metrics.keys()):
+                writer.writerow([key, metrics[key]])
+
+
+def generate_ifu_experiment_report(output_dir: str) -> dict[str, Any]:
+    """Generate a compact report from saved IFU experiment artifacts.
+
+    Args:
+        output_dir (str): Directory containing saved experiment outputs.
+
+    Raises:
+        FileNotFoundError: If ``summary.json`` is missing.
+
+    Returns:
+        dict[str, Any]: Compact report with stage/metric summaries and artifact
+            key and shape diagnostics.
+    """
+    out_dir = Path(output_dir)
+    summary_path = out_dir / "summary.json"
+    if not summary_path.exists():
+        raise FileNotFoundError(f"missing required summary file: {summary_path}")
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    report: dict[str, Any] = {
+        "summary": {
+            "stages": summary.get("stages"),
+            "optimization": summary.get("optimization"),
+            "variational": summary.get("variational"),
+            "metrics": summary.get("metrics"),
+            "run_metadata": summary.get("run_metadata"),
+        },
+        "artifacts": {},
+    }
+
+    science_path = out_dir / "science_products.npz"
+    if science_path.exists():
+        with np.load(science_path) as data:
+            report["artifacts"]["science_products"] = {
+                key: {"shape": list(data[key].shape)} for key in data.files
+            }
+
+    pred_path = out_dir / "predictive_summary.npz"
+    if pred_path.exists():
+        with np.load(pred_path) as data:
+            report["artifacts"]["predictive_summary_keys"] = list(data.files)
+
+    residual_path = out_dir / "residual_products.npz"
+    if residual_path.exists():
+        with np.load(residual_path) as data:
+            report["artifacts"]["residual_products_keys"] = list(data.files)
+
+    return report

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1051,7 +1051,7 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
                 science_products[new_key] = np.asarray(residual_products[old_key])
 
     if len(science_products) > 0:
-        np.savez(out_dir / "science_products.npz", **science_products)
+        np.savez_compressed(out_dir / "science_products.npz", **science_products)
 
     metrics = outputs.get("metrics")
     if isinstance(metrics, Mapping):

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -283,7 +283,11 @@ def normalize_experiment_config(config: Mapping[str, Any]) -> dict[str, Any]:
             "auto_resume_latest": bool(run_cfg.get("auto_resume_latest", False)),
             "fail_on_stage_failure": bool(run_cfg.get("fail_on_stage_failure", False)),
             "checkpoint_policy": (
-                lambda v: v.strip().lower() if isinstance(v, str) and v.strip() else "standard"
+                lambda v: (
+                    v.strip().lower()
+                    if isinstance(v, str) and v.strip()
+                    else "standard"
+                )
             )(run_cfg.get("checkpoint_policy")),
             "seed": int(run_cfg.get("seed", 0)),
             "output_dir": run_cfg.get("output_dir", "outputs/ifu_science"),
@@ -652,9 +656,7 @@ def _run_optimization_stage(
         # Use cumulative steps_completed from checkpoint metadata; fall back to
         # per-chunk steps_run only if metadata is absent (legacy checkpoints).
         steps_completed = int(
-            payload.get("metadata", {}).get(
-                "steps_completed", latest_result.steps_run
-            )
+            payload.get("metadata", {}).get("steps_completed", latest_result.steps_run)
         )
         remaining = max(0, remaining - steps_completed)
         # Restore chunk_idx from the resumed filename so subsequent saves do
@@ -830,9 +832,7 @@ def _run_variational_stage(
         # Use cumulative steps_completed from checkpoint metadata; fall back to
         # per-chunk steps_run only if metadata is absent (legacy checkpoints).
         steps_completed = int(
-            payload.get("metadata", {}).get(
-                "steps_completed", latest_result.steps_run
-            )
+            payload.get("metadata", {}).get("steps_completed", latest_result.steps_run)
         )
         remaining = max(0, remaining - steps_completed)
         # Restore chunk_idx from the resumed filename so subsequent saves do
@@ -1266,8 +1266,9 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
             json.dumps(_to_jsonable(dict(failure_artifacts)), indent=2),
             encoding="utf-8",
         )
-    
+
     return
+
 
 def generate_ifu_experiment_report(output_dir: str) -> dict[str, Any]:
     """Generate a compact report from saved IFU experiment artifacts.

--- a/scripts/generate_ifu_experiment_report.py
+++ b/scripts/generate_ifu_experiment_report.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import argparse
+import json
+from pathlib import Path
+
+from rubix.inference.experiment import generate_ifu_experiment_report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate compact JSON report from saved IFU experiment outputs."
+    )
+    parser.add_argument("--output-dir", type=str, required=True)
+    parser.add_argument(
+        "--report-path",
+        type=str,
+        default=None,
+        help="Optional custom path for report JSON (defaults to <output-dir>/science_report.json).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    report = generate_ifu_experiment_report(args.output_dir)
+
+    if args.report_path is None:
+        report_path = Path(args.output_dir) / "science_report.json"
+    else:
+        report_path = Path(args.report_path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -434,9 +434,9 @@ def test_run_ifu_experiment_smoke_only_computes_metrics(tmp_path):
     assert outputs["residual_products"] is not None
 
     save_ifu_experiment_outputs(outputs, str(tmp_path / "saved_smoke"))
-    science_products = np.load(tmp_path / "saved_smoke" / "science_products.npz")
-    assert "residual_cube" in science_products.files
-    assert "chi2_cube" in science_products.files
+    with np.load(tmp_path / "saved_smoke" / "science_products.npz") as science_products:
+        assert "residual_cube" in science_products.files
+        assert "chi2_cube" in science_products.files
 
 
 def test_generate_ifu_experiment_report_requires_summary(tmp_path):

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -10,6 +10,7 @@ from rubix.inference.checkpoint import (
     save_checkpoint,
 )
 from rubix.inference.experiment import (
+    generate_ifu_experiment_report,
     normalize_experiment_config,
     run_ifu_experiment,
     save_ifu_experiment_outputs,
@@ -135,6 +136,14 @@ def test_run_ifu_experiment_and_save_outputs(tmp_path):
     assert (tmp_path / "saved" / "summary.json").exists()
     assert (tmp_path / "saved" / "predictive_summary.npz").exists()
     assert (tmp_path / "saved" / "residual_products.npz").exists()
+    assert (tmp_path / "saved" / "science_products.npz").exists()
+    assert (tmp_path / "saved" / "science_metrics.csv").exists()
+
+    report = generate_ifu_experiment_report(str(tmp_path / "saved"))
+    assert "summary" in report
+    assert "artifacts" in report
+    assert "science_products" in report["artifacts"]
+    assert "posterior_mean_cube" in report["artifacts"]["science_products"]
 
 
 def test_normalize_experiment_config_rejects_invalid_checkpoint_interval():
@@ -384,7 +393,9 @@ def test_smoke_only_rejects_both_sigma_and_inv_variance(tmp_path):
         assert "sigma" in str(exc)
         assert "inv_variance" in str(exc)
     else:
-        raise AssertionError("Expected ValueError when both sigma and inv_variance provided in smoke_only mode")
+        raise AssertionError(
+            "Expected ValueError when both sigma and inv_variance provided in smoke_only mode"
+        )
 
 
 def test_run_ifu_experiment_smoke_only_computes_metrics(tmp_path):
@@ -421,3 +432,17 @@ def test_run_ifu_experiment_smoke_only_computes_metrics(tmp_path):
     assert outputs["predictive_summary"] is None
     assert outputs["metrics"] is not None
     assert outputs["residual_products"] is not None
+
+    save_ifu_experiment_outputs(outputs, str(tmp_path / "saved_smoke"))
+    science_products = np.load(tmp_path / "saved_smoke" / "science_products.npz")
+    assert "residual_cube" in science_products.files
+    assert "chi2_cube" in science_products.files
+
+
+def test_generate_ifu_experiment_report_requires_summary(tmp_path):
+    try:
+        generate_ifu_experiment_report(str(tmp_path))
+    except FileNotFoundError as exc:
+        assert "summary.json" in str(exc)
+    else:
+        raise AssertionError("Expected FileNotFoundError when summary.json is missing")


### PR DESCRIPTION
## Summary
- add standardized science artifact export in `save_ifu_experiment_outputs`
  - `science_products.npz` with canonical cube product names
  - `science_metrics.csv` for compact scalar metric export
- add `generate_ifu_experiment_report(output_dir)` API to summarize saved artifacts
- add `scripts/generate_ifu_experiment_report.py` CLI for report generation
- extend inference workflow docs with artifact/report usage
- extend experiment tests for new artifacts and report generation

## Validation
- pre-commit run on changed files
- python -m compileall on updated inference module, tests, and script

## Notes
- pytest execution remains flaky/hanging in this sandbox JAX runtime; lint/doc/style and compile checks were used for gating here.
