### PR TITLE
feat(guardrails): add versioned threshold profiles and loader integration

### DIFF
--- a/bench/check_inference_guardrails.py
+++ b/bench/check_inference_guardrails.py
@@ -85,7 +85,15 @@ def _resolve_with_profile(
 def main() -> None:
     args = parse_args()
     cfg = read_yaml(args.threshold_config)
+    if not isinstance(cfg, Mapping):
+        raise SystemExit(
+            f"threshold config {args.threshold_config} must contain a top-level mapping"
+        )
     profiles = cfg.get("profiles") or {}
+    if not isinstance(profiles, Mapping):
+        raise SystemExit(
+            f"threshold config {args.threshold_config} field 'profiles' must be a mapping"
+        )
     profile = profiles.get(args.profile)
     if not isinstance(profile, Mapping):
         raise SystemExit(

--- a/bench/check_inference_guardrails.py
+++ b/bench/check_inference_guardrails.py
@@ -2,9 +2,11 @@
 import argparse
 import json
 from pathlib import Path
+from typing import Any, Mapping, Optional
 
 import jax.numpy as jnp
 
+from rubix.config.config import PARENT_DIR
 from rubix.core.data import Galaxy, GasData, RubixData, StarsData
 from rubix.inference import (
     OptimizationObjectiveThresholds,
@@ -12,7 +14,9 @@ from rubix.inference import (
     benchmark_ifu_cube_optimization,
     benchmark_result_to_dict,
     check_ifu_optimization_guardrails,
+    load_guardrail_threshold_profile,
 )
+from rubix.utils import read_yaml
 
 
 class _SyntheticPipeline:
@@ -47,23 +51,61 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run optimization benchmark and assert runtime/loss guardrails."
     )
-    parser.add_argument("--nx", type=int, default=8)
-    parser.add_argument("--ny", type=int, default=8)
-    parser.add_argument("--nw", type=int, default=64)
-    parser.add_argument("--max-steps", type=int, default=120)
-    parser.add_argument("--repeats", type=int, default=2)
-    parser.add_argument("--max-mean-runtime-s", type=float, default=3.0)
-    parser.add_argument("--max-median-runtime-s", type=float, default=3.0)
-    parser.add_argument("--max-final-loss", type=float, default=1e-3)
-    parser.add_argument("--max-best-loss", type=float, default=1e-3)
+    parser.add_argument(
+        "--threshold-config",
+        type=str,
+        default=str(Path(PARENT_DIR) / "guardrail_thresholds.yml"),
+    )
+    parser.add_argument("--profile", type=str, default="small_cube_default")
+    parser.add_argument("--nx", type=int, default=None)
+    parser.add_argument("--ny", type=int, default=None)
+    parser.add_argument("--nw", type=int, default=None)
+    parser.add_argument("--max-steps", type=int, default=None)
+    parser.add_argument("--repeats", type=int, default=None)
+    parser.add_argument("--max-mean-runtime-s", type=float, default=None)
+    parser.add_argument("--max-median-runtime-s", type=float, default=None)
+    parser.add_argument("--max-final-loss", type=float, default=None)
+    parser.add_argument("--max-best-loss", type=float, default=None)
     parser.add_argument("--output-json", type=str, default="")
     return parser.parse_args()
 
 
+def _resolve_with_profile(
+    override: Optional[float],
+    profile_mapping: Mapping[str, Any],
+    key: str,
+) -> Optional[float]:
+    """Resolve value from CLI override or profile mapping."""
+    if override is not None:
+        return override
+    value = profile_mapping.get(key)
+    return None if value is None else float(value)
+
+
 def main() -> None:
     args = parse_args()
+    cfg = read_yaml(args.threshold_config)
+    profiles = cfg.get("profiles") or {}
+    profile = profiles.get(args.profile)
+    if not isinstance(profile, Mapping):
+        raise SystemExit(
+            f"profile '{args.profile}' not found in {args.threshold_config}"
+        )
+    benchmark_profile = profile.get("benchmark") or {}
+    if not isinstance(benchmark_profile, Mapping):
+        raise SystemExit(f"profile '{args.profile}' benchmark section must be mapping")
 
-    cube = jnp.ones((args.nx, args.ny, args.nw), dtype=jnp.float32)
+    nx = int(_resolve_with_profile(args.nx, benchmark_profile, "nx") or 8)
+    ny = int(_resolve_with_profile(args.ny, benchmark_profile, "ny") or 8)
+    nw = int(_resolve_with_profile(args.nw, benchmark_profile, "nw") or 64)
+    max_steps = int(
+        _resolve_with_profile(args.max_steps, benchmark_profile, "max_steps") or 120
+    )
+    repeats = int(
+        _resolve_with_profile(args.repeats, benchmark_profile, "repeats") or 2
+    )
+
+    cube = jnp.ones((nx, ny, nw), dtype=jnp.float32)
     target = 1.5 * cube
 
     benchmark_result = benchmark_ifu_cube_optimization(
@@ -72,19 +114,40 @@ def main() -> None:
         static_data=_make_data(),
         target=target,
         learning_rate=0.1,
-        max_steps=args.max_steps,
+        max_steps=max_steps,
         tol=1e-8,
-        repeats=args.repeats,
+        repeats=repeats,
         warmup=True,
     )
 
+    runtime_thresholds, objective_thresholds = load_guardrail_threshold_profile(
+        config_path=args.threshold_config,
+        profile_name=args.profile,
+        mode="optimization",
+    )
     runtime_thresholds = RuntimeThresholds(
-        max_mean_runtime_s=args.max_mean_runtime_s,
-        max_median_runtime_s=args.max_median_runtime_s,
+        max_mean_runtime_s=_resolve_with_profile(
+            args.max_mean_runtime_s,
+            {"max_mean_runtime_s": runtime_thresholds.max_mean_runtime_s},
+            "max_mean_runtime_s",
+        ),
+        max_median_runtime_s=_resolve_with_profile(
+            args.max_median_runtime_s,
+            {"max_median_runtime_s": runtime_thresholds.max_median_runtime_s},
+            "max_median_runtime_s",
+        ),
     )
     objective_thresholds = OptimizationObjectiveThresholds(
-        max_final_loss=args.max_final_loss,
-        max_best_loss=args.max_best_loss,
+        max_final_loss=_resolve_with_profile(
+            args.max_final_loss,
+            {"max_final_loss": objective_thresholds.max_final_loss},
+            "max_final_loss",
+        ),
+        max_best_loss=_resolve_with_profile(
+            args.max_best_loss,
+            {"max_best_loss": objective_thresholds.max_best_loss},
+            "max_best_loss",
+        ),
     )
 
     check = check_ifu_optimization_guardrails(
@@ -94,11 +157,22 @@ def main() -> None:
     )
 
     payload = {
+        "profile": {
+            "name": args.profile,
+            "threshold_config": args.threshold_config,
+            "benchmark": {
+                "nx": nx,
+                "ny": ny,
+                "nw": nw,
+                "max_steps": max_steps,
+                "repeats": repeats,
+            },
+        },
         "benchmark": benchmark_result_to_dict(benchmark_result),
         "guardrail": {
             "passed": check.passed,
             "message": check.message,
-            "failed_conditions": check.failed_conditions,
+            "failed_conditions": list(check.failed_conditions),
         },
     }
 

--- a/bench/check_inference_guardrails.py
+++ b/bench/check_inference_guardrails.py
@@ -70,16 +70,53 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _resolve_with_profile(
+def _resolve_int_with_profile(
+    override: Optional[int],
+    profile_mapping: Mapping[str, Any],
+    key: str,
+) -> Optional[int]:
+    """Resolve an integer value from CLI override or profile mapping.
+
+    Raises:
+        SystemExit: If the profile value is not a plain ``int`` (e.g. a float
+            or bool), so invalid profile entries fail fast instead of silently
+            truncating.
+    """
+    if override is not None:
+        return override
+    value = profile_mapping.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise SystemExit(
+            f"profile key '{key}' must be an integer, "
+            f"got {type(value).__name__!r}: {value!r}"
+        )
+    return value
+
+
+def _resolve_float_with_profile(
     override: Optional[float],
     profile_mapping: Mapping[str, Any],
     key: str,
 ) -> Optional[float]:
-    """Resolve value from CLI override or profile mapping."""
+    """Resolve a float value from CLI override or profile mapping.
+
+    Raises:
+        SystemExit: If the profile value is a bool or non-numeric type so
+            config mistakes fail fast.
+    """
     if override is not None:
         return override
     value = profile_mapping.get(key)
-    return None if value is None else float(value)
+    if value is None:
+        return None
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise SystemExit(
+            f"profile key '{key}' must be a number, "
+            f"got {type(value).__name__!r}: {value!r}"
+        )
+    return float(value)
 
 
 def main() -> None:
@@ -103,14 +140,14 @@ def main() -> None:
     if not isinstance(benchmark_profile, Mapping):
         raise SystemExit(f"profile '{args.profile}' benchmark section must be mapping")
 
-    nx = int(_resolve_with_profile(args.nx, benchmark_profile, "nx") or 8)
-    ny = int(_resolve_with_profile(args.ny, benchmark_profile, "ny") or 8)
-    nw = int(_resolve_with_profile(args.nw, benchmark_profile, "nw") or 64)
-    max_steps = int(
-        _resolve_with_profile(args.max_steps, benchmark_profile, "max_steps") or 120
+    nx = _resolve_int_with_profile(args.nx, benchmark_profile, "nx") or 8
+    ny = _resolve_int_with_profile(args.ny, benchmark_profile, "ny") or 8
+    nw = _resolve_int_with_profile(args.nw, benchmark_profile, "nw") or 64
+    max_steps = (
+        _resolve_int_with_profile(args.max_steps, benchmark_profile, "max_steps") or 120
     )
-    repeats = int(
-        _resolve_with_profile(args.repeats, benchmark_profile, "repeats") or 2
+    repeats = (
+        _resolve_int_with_profile(args.repeats, benchmark_profile, "repeats") or 2
     )
 
     cube = jnp.ones((nx, ny, nw), dtype=jnp.float32)
@@ -134,24 +171,24 @@ def main() -> None:
         mode="optimization",
     )
     runtime_thresholds = RuntimeThresholds(
-        max_mean_runtime_s=_resolve_with_profile(
+        max_mean_runtime_s=_resolve_float_with_profile(
             args.max_mean_runtime_s,
             {"max_mean_runtime_s": runtime_thresholds.max_mean_runtime_s},
             "max_mean_runtime_s",
         ),
-        max_median_runtime_s=_resolve_with_profile(
+        max_median_runtime_s=_resolve_float_with_profile(
             args.max_median_runtime_s,
             {"max_median_runtime_s": runtime_thresholds.max_median_runtime_s},
             "max_median_runtime_s",
         ),
     )
     objective_thresholds = OptimizationObjectiveThresholds(
-        max_final_loss=_resolve_with_profile(
+        max_final_loss=_resolve_float_with_profile(
             args.max_final_loss,
             {"max_final_loss": objective_thresholds.max_final_loss},
             "max_final_loss",
         ),
-        max_best_loss=_resolve_with_profile(
+        max_best_loss=_resolve_float_with_profile(
             args.max_best_loss,
             {"max_best_loss": objective_thresholds.max_best_loss},
             "max_best_loss",

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -407,8 +407,10 @@ For CI-style threshold checks on a representative synthetic IFU size:
 .. code-block:: bash
 
    python bench/check_inference_guardrails.py \
-     --nx 8 --ny 8 --nw 64 \
-     --max-steps 120 \
-     --max-mean-runtime-s 3.0 \
-     --max-final-loss 1e-3 \
+     --threshold-config rubix/config/guardrail_thresholds.yml \
+     --profile small_cube_default \
      --output-json outputs/guardrails/opt_guardrail.json
+
+Thresholds and benchmark sizes are versioned in
+``rubix/config/guardrail_thresholds.yml``. CLI flags can still override profile
+values for ad-hoc checks.

--- a/rubix/config/guardrail_thresholds.yml
+++ b/rubix/config/guardrail_thresholds.yml
@@ -1,0 +1,30 @@
+profiles:
+  small_cube_default:
+    benchmark:
+      nx: 8
+      ny: 8
+      nw: 64
+      max_steps: 120
+      repeats: 2
+    optimization:
+      runtime:
+        max_mean_runtime_s: 3.0
+        max_median_runtime_s: 3.0
+      objective:
+        max_final_loss: 1.0e-3
+        max_best_loss: 1.0e-3
+
+  ci_fast:
+    benchmark:
+      nx: 6
+      ny: 6
+      nw: 32
+      max_steps: 80
+      repeats: 2
+    optimization:
+      runtime:
+        max_mean_runtime_s: 2.5
+        max_median_runtime_s: 2.5
+      objective:
+        max_final_loss: 2.0e-3
+        max_best_loss: 2.0e-3

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -49,6 +49,7 @@ from .performance_guardrails import (
     VIObjectiveThresholds,
     check_ifu_optimization_guardrails,
     check_vi_guardrails,
+    load_guardrail_threshold_profile,
 )
 from .posterior_predictive import (
     compute_residual_products,
@@ -108,6 +109,7 @@ __all__ = [
     "compute_residual_products",
     "check_ifu_optimization_guardrails",
     "check_vi_guardrails",
+    "load_guardrail_threshold_profile",
     "estimate_array_nbytes",
     "finite_difference_grad",
     "forward",

--- a/rubix/inference/performance_guardrails.py
+++ b/rubix/inference/performance_guardrails.py
@@ -74,6 +74,8 @@ def load_guardrail_threshold_profile(
         raise ValueError("mode must be 'optimization' or 'variational'")
 
     cfg = read_yaml(str(config_path))
+    if not isinstance(cfg, Mapping):
+        raise ValueError("guardrail config must be a mapping")
     profiles = cfg.get("profiles")
     if not isinstance(profiles, Mapping):
         raise ValueError("guardrail config must contain a 'profiles' mapping")

--- a/rubix/inference/performance_guardrails.py
+++ b/rubix/inference/performance_guardrails.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
-from typing import Optional
+from pathlib import Path
+from typing import Any, Mapping, Optional, Union
+
+from rubix.utils import read_yaml
 
 from .benchmark import IFUCubeBenchmarkResult
 from .vi_benchmark import VIBenchmarkResult
@@ -35,6 +38,87 @@ class PerformanceCheckResult:
 
     passed: bool
     message: str
+    failed_conditions: tuple[str, ...] = ()
+
+
+def _as_optional_float(value: Any) -> Optional[float]:
+    """Convert supported scalar value to optional float."""
+    if value is None:
+        return None
+    return float(value)
+
+
+def load_guardrail_threshold_profile(
+    config_path: Union[str, Path],
+    profile_name: str,
+    mode: str,
+) -> tuple[
+    RuntimeThresholds,
+    Union[OptimizationObjectiveThresholds, VIObjectiveThresholds],
+]:
+    """Load runtime/objective thresholds from a versioned YAML profile.
+
+    Args:
+        config_path (Union[str, Path]): Guardrail threshold config path.
+        profile_name (str): Profile key under ``profiles``.
+        mode (str): One of ``'optimization'`` or ``'variational'``.
+
+    Raises:
+        ValueError: If config schema, profile, or mode entries are invalid.
+
+    Returns:
+        tuple[RuntimeThresholds, Union[OptimizationObjectiveThresholds,
+        VIObjectiveThresholds]]: Runtime and objective thresholds.
+    """
+    if mode not in {"optimization", "variational"}:
+        raise ValueError("mode must be 'optimization' or 'variational'")
+
+    cfg = read_yaml(str(config_path))
+    profiles = cfg.get("profiles")
+    if not isinstance(profiles, Mapping):
+        raise ValueError("guardrail config must contain a 'profiles' mapping")
+
+    profile = profiles.get(profile_name)
+    if not isinstance(profile, Mapping):
+        raise ValueError(
+            f"profile '{profile_name}' not found in guardrail config {config_path}"
+        )
+
+    mode_cfg = profile.get(mode)
+    if not isinstance(mode_cfg, Mapping):
+        raise ValueError(f"profile '{profile_name}' must define a '{mode}' mapping")
+
+    runtime_cfg = mode_cfg.get("runtime") or {}
+    if not isinstance(runtime_cfg, Mapping):
+        raise ValueError(f"profile '{profile_name}' {mode}.runtime must be a mapping")
+
+    runtime = RuntimeThresholds(
+        max_mean_runtime_s=_as_optional_float(runtime_cfg.get("max_mean_runtime_s")),
+        max_median_runtime_s=_as_optional_float(
+            runtime_cfg.get("max_median_runtime_s")
+        ),
+    )
+
+    objective_cfg = mode_cfg.get("objective") or {}
+    if not isinstance(objective_cfg, Mapping):
+        raise ValueError(f"profile '{profile_name}' {mode}.objective must be a mapping")
+
+    if mode == "optimization":
+        objective = OptimizationObjectiveThresholds(
+            max_final_loss=_as_optional_float(objective_cfg.get("max_final_loss")),
+            max_best_loss=_as_optional_float(objective_cfg.get("max_best_loss")),
+        )
+    else:
+        objective = VIObjectiveThresholds(
+            max_final_objective=_as_optional_float(
+                objective_cfg.get("max_final_objective")
+            ),
+            max_best_objective=_as_optional_float(
+                objective_cfg.get("max_best_objective")
+            ),
+        )
+
+    return runtime, objective
 
 
 def _check_runtime(
@@ -99,11 +183,13 @@ def check_ifu_optimization_guardrails(
         return PerformanceCheckResult(
             passed=False,
             message="; ".join(errors),
+            failed_conditions=tuple(errors),
         )
 
     return PerformanceCheckResult(
         passed=True,
         message="optimization benchmark satisfies configured thresholds",
+        failed_conditions=(),
     )
 
 
@@ -146,9 +232,11 @@ def check_vi_guardrails(
         return PerformanceCheckResult(
             passed=False,
             message="; ".join(errors),
+            failed_conditions=tuple(errors),
         )
 
     return PerformanceCheckResult(
         passed=True,
         message="VI benchmark satisfies configured thresholds",
+        failed_conditions=(),
     )

--- a/rubix/inference/performance_guardrails.py
+++ b/rubix/inference/performance_guardrails.py
@@ -42,9 +42,24 @@ class PerformanceCheckResult:
 
 
 def _as_optional_float(value: Any) -> Optional[float]:
-    """Convert supported scalar value to optional float."""
+    """Convert supported scalar value to optional float.
+
+    Raises:
+        ValueError: If *value* is a ``bool`` (which is a numeric subtype but
+            almost always indicates a YAML/config mistake) or any other
+            non-numeric type.
+    """
     if value is None:
         return None
+    if isinstance(value, bool):
+        raise ValueError(
+            f"expected a numeric value, got bool {value!r}; "
+            "check the guardrail config for a YAML boolean where a number was intended"
+        )
+    if not isinstance(value, (int, float)):
+        raise ValueError(
+            f"expected a numeric value, got {type(value).__name__!r}: {value!r}"
+        )
     return float(value)
 
 

--- a/tests/test_inference_performance_guardrails.py
+++ b/tests/test_inference_performance_guardrails.py
@@ -1,3 +1,5 @@
+import yaml
+
 from rubix.inference.benchmark import IFUCubeBenchmarkResult
 from rubix.inference.performance_guardrails import (
     OptimizationObjectiveThresholds,
@@ -5,6 +7,7 @@ from rubix.inference.performance_guardrails import (
     VIObjectiveThresholds,
     check_ifu_optimization_guardrails,
     check_vi_guardrails,
+    load_guardrail_threshold_profile,
 )
 from rubix.inference.vi_benchmark import VIBenchmarkResult
 
@@ -64,6 +67,7 @@ def test_check_ifu_optimization_guardrails_fails_on_runtime_and_loss():
     assert check.passed is False
     assert "mean runtime" in check.message
     assert "final loss" in check.message
+    assert len(check.failed_conditions) >= 1
 
 
 def test_check_vi_guardrails_passes_within_limits():
@@ -83,3 +87,62 @@ def test_check_vi_guardrails_fails_on_objective():
     check = check_vi_guardrails(result, runtime, objective)
     assert check.passed is False
     assert "final objective" in check.message
+    assert len(check.failed_conditions) >= 1
+
+
+def test_load_guardrail_threshold_profile_optimization(tmp_path):
+    cfg = {
+        "profiles": {
+            "test_profile": {
+                "optimization": {
+                    "runtime": {
+                        "max_mean_runtime_s": 1.5,
+                        "max_median_runtime_s": 1.25,
+                    },
+                    "objective": {
+                        "max_final_loss": 1e-4,
+                        "max_best_loss": 1e-5,
+                    },
+                }
+            }
+        }
+    }
+    path = tmp_path / "guardrail.yml"
+    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+    runtime, objective = load_guardrail_threshold_profile(
+        path, profile_name="test_profile", mode="optimization"
+    )
+    assert runtime.max_mean_runtime_s == 1.5
+    assert runtime.max_median_runtime_s == 1.25
+    assert objective.max_final_loss == 1e-4
+    assert objective.max_best_loss == 1e-5
+
+
+def test_load_guardrail_threshold_profile_variational(tmp_path):
+    cfg = {
+        "profiles": {
+            "test_profile": {
+                "variational": {
+                    "runtime": {
+                        "max_mean_runtime_s": 2.0,
+                        "max_median_runtime_s": 1.9,
+                    },
+                    "objective": {
+                        "max_final_objective": 1e-3,
+                        "max_best_objective": 8e-4,
+                    },
+                }
+            }
+        }
+    }
+    path = tmp_path / "guardrail.yml"
+    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+    runtime, objective = load_guardrail_threshold_profile(
+        path, profile_name="test_profile", mode="variational"
+    )
+    assert runtime.max_mean_runtime_s == 2.0
+    assert runtime.max_median_runtime_s == 1.9
+    assert objective.max_final_objective == 1e-3
+    assert objective.max_best_objective == 8e-4


### PR DESCRIPTION
## Summary
- add versioned guardrail thresholds in `rubix/config/guardrail_thresholds.yml` with named profiles
- update `bench/check_inference_guardrails.py` to load profile-based benchmark/threshold settings from config
- keep CLI overrides for ad-hoc local tuning
- fix integration bug from merge stack: `PerformanceCheckResult` now includes `failed_conditions`
- add threshold-profile loader API (`load_guardrail_threshold_profile`) in `rubix.inference.performance_guardrails`
- add tests for threshold-profile loading and failed-condition reporting
- update inference workflow docs to use profile-based guardrail checks

## Validation
- pre-commit run on changed files
- python -m compileall on updated module/script/tests

## Notes
- targeted pytest execution in this sandbox still intermittently hangs with local JAX runtime behavior; lint/style and compile checks were used as the gating checks.
