### PR TITLE
ci(guardrails): integrate profile-based inference guardrail checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           --output-json outputs/guardrails/opt_guardrail_ci.json
 
     - name: Upload guardrail report artifact
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: guardrail-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,39 @@ jobs:
       env:
         ILLUSTRIS_API_KEY: ${{ secrets.ILLUSTRIS_API_KEY }} # need this to run the tests
 
+  guardrail-check:
+    name: Guardrail Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: Install Python package
+      run: |
+        python -m pip install setuptools
+        python -m pip install .[cpu,tests]
+
+    - name: Run guardrail benchmark profile
+      run: |
+        python bench/check_inference_guardrails.py \
+          --threshold-config rubix/config/guardrail_thresholds.yml \
+          --profile ci_fast \
+          --output-json outputs/guardrails/opt_guardrail_ci.json
+
+    - name: Upload guardrail report artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: guardrail-report
+        path: outputs/guardrails/opt_guardrail_ci.json
+
   coverage:
     name: Coverage Testing
     runs-on: ubuntu-latest

--- a/bench/check_inference_guardrails.py
+++ b/bench/check_inference_guardrails.py
@@ -146,9 +146,7 @@ def main() -> None:
     max_steps = (
         _resolve_int_with_profile(args.max_steps, benchmark_profile, "max_steps") or 120
     )
-    repeats = (
-        _resolve_int_with_profile(args.repeats, benchmark_profile, "repeats") or 2
-    )
+    repeats = _resolve_int_with_profile(args.repeats, benchmark_profile, "repeats") or 2
 
     cube = jnp.ones((nx, ny, nw), dtype=jnp.float32)
     target = 1.5 * cube

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -414,3 +414,6 @@ For CI-style threshold checks on a representative synthetic IFU size:
 Thresholds and benchmark sizes are versioned in
 ``rubix/config/guardrail_thresholds.yml``. CLI flags can still override profile
 values for ad-hoc checks.
+
+CI runs the same script with the ``ci_fast`` profile and stores
+``outputs/guardrails/opt_guardrail_ci.json`` as a workflow artifact.


### PR DESCRIPTION
## Summary
- add a dedicated CI job (`guardrail-check`) in `.github/workflows/ci.yml`
- run `bench/check_inference_guardrails.py` using versioned profile config:
  - `--threshold-config rubix/config/guardrail_thresholds.yml`
  - `--profile ci_fast`
- upload guardrail JSON output as CI artifact:
  - `outputs/guardrails/opt_guardrail_ci.json`
- update inference docs with CI guardrail behavior

## Validation
- pre-commit run --files .github/workflows/ci.yml docs/inference_workflows.rst
