### PR TITLE
feat(inference): add run manifest sidecar for science provenance

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -377,7 +377,7 @@ Real Data Runbook
 6. If interrupted, resume from latest stage checkpoint by setting
    ``optimization.resume_checkpoint`` or ``variational.resume_checkpoint`` to
    ``latest`` (or set ``run.auto_resume_latest: true``).
-7. Inspect outputs in ``run.output_dir``:
+7. Inspect the standard artifacts in ``run.output_dir``:
    ``summary.json``, ``predictive_summary.npz``, ``residual_products.npz``,
    ``science_products.npz``, ``science_metrics.csv``, and
    ``run_manifest.json``.

--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -379,7 +379,8 @@ Real Data Runbook
    ``latest`` (or set ``run.auto_resume_latest: true``).
 7. Inspect outputs in ``run.output_dir``:
    ``summary.json``, ``predictive_summary.npz``, ``residual_products.npz``,
-   ``science_products.npz``, and ``science_metrics.csv``.
+   ``science_products.npz``, ``science_metrics.csv``, and
+   ``run_manifest.json``.
 
 8. Generate a compact report for quick review:
 

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1208,6 +1208,12 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
         json.dumps(_to_jsonable(summary), indent=2),
         encoding="utf-8",
     )
+    artifact_inventory: dict[str, dict[str, Any]] = {
+        "summary.json": {
+            "exists": True,
+            "kind": "json",
+        }
+    }
 
     predictive_summary = outputs.get("predictive_summary")
     if isinstance(predictive_summary, Mapping):
@@ -1215,6 +1221,11 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
             out_dir / "predictive_summary.npz",
             **{k: np.asarray(v) for k, v in predictive_summary.items()},
         )
+        artifact_inventory["predictive_summary.npz"] = {
+            "exists": True,
+            "kind": "npz",
+            "keys": sorted(list(predictive_summary.keys())),
+        }
 
     residual_products = outputs.get("residual_products")
     if isinstance(residual_products, Mapping):
@@ -1222,6 +1233,11 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
             out_dir / "residual_products.npz",
             **{k: np.asarray(v) for k, v in residual_products.items()},
         )
+        artifact_inventory["residual_products.npz"] = {
+            "exists": True,
+            "kind": "npz",
+            "keys": sorted(list(residual_products.keys())),
+        }
 
     science_products: dict[str, np.ndarray] = {}
     if isinstance(predictive_summary, Mapping):
@@ -1250,6 +1266,11 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
 
     if len(science_products) > 0:
         np.savez_compressed(out_dir / "science_products.npz", **science_products)
+        artifact_inventory["science_products.npz"] = {
+            "exists": True,
+            "kind": "npz",
+            "keys": sorted(list(science_products.keys())),
+        }
 
     metrics = outputs.get("metrics")
     if isinstance(metrics, Mapping):
@@ -1260,6 +1281,11 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
             writer.writerow(["metric", "value"])
             for key in sorted(metrics.keys()):
                 writer.writerow([key, metrics[key]])
+        artifact_inventory["science_metrics.csv"] = {
+            "exists": True,
+            "kind": "csv",
+            "rows": len(metrics),
+        }
 
     failure_artifacts = outputs.get("failure_artifacts")
     if isinstance(failure_artifacts, Mapping):
@@ -1267,6 +1293,22 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
             json.dumps(_to_jsonable(dict(failure_artifacts)), indent=2),
             encoding="utf-8",
         )
+        artifact_inventory["failure_report.json"] = {
+            "exists": True,
+            "kind": "json",
+        }
+
+    manifest = {
+        "generated_at_utc": _utc_now_iso(),
+        "output_dir": str(out_dir),
+        "run_metadata": outputs.get("run_metadata"),
+        "stages": outputs.get("stages"),
+        "artifacts": artifact_inventory,
+    }
+    (out_dir / "run_manifest.json").write_text(
+        json.dumps(_to_jsonable(manifest), indent=2),
+        encoding="utf-8",
+    )
 
     return
 
@@ -1299,6 +1341,11 @@ def generate_ifu_experiment_report(output_dir: str) -> dict[str, Any]:
         },
         "artifacts": {},
     }
+    manifest_path = out_dir / "run_manifest.json"
+    if manifest_path.exists():
+        report["manifest"] = json.loads(manifest_path.read_text(encoding="utf-8"))
+    else:
+        report["manifest"] = None
 
     science_path = out_dir / "science_products.npz"
     if science_path.exists():

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1298,6 +1298,10 @@ def save_ifu_experiment_outputs(outputs: Mapping[str, Any], output_dir: str) -> 
             "kind": "json",
         }
 
+    artifact_inventory["run_manifest.json"] = {
+        "exists": True,
+        "kind": "json",
+    }
     manifest = {
         "generated_at_utc": _utc_now_iso(),
         "output_dir": str(out_dir),
@@ -1323,8 +1327,13 @@ def generate_ifu_experiment_report(output_dir: str) -> dict[str, Any]:
         FileNotFoundError: If ``summary.json`` is missing.
 
     Returns:
-        dict[str, Any]: Compact report with stage/metric summaries and artifact
-            key and shape diagnostics.
+        dict[str, Any]: Compact report with the following keys:
+
+        - ``"summary"``: stage/metric summaries from ``summary.json``.
+        - ``"artifacts"``: artifact key and shape diagnostics for science,
+          predictive, and residual products.
+        - ``"manifest"``: parsed contents of ``run_manifest.json`` when the
+          sidecar exists, or ``None`` when it is absent.
     """
     out_dir = Path(output_dir)
     summary_path = out_dir / "summary.json"

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -159,6 +159,8 @@ def test_run_ifu_experiment_and_save_outputs(tmp_path):
     assert "summary" in report
     assert "artifacts" in report
     assert report["manifest"] is not None
+    assert "run_manifest.json" in report["manifest"]["artifacts"]
+    assert report["manifest"]["artifacts"]["run_manifest.json"]["kind"] == "json"
     assert "science_products" in report["artifacts"]
     assert "posterior_mean_cube" in report["artifacts"]["science_products"]
 

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -149,6 +149,7 @@ def test_run_ifu_experiment_and_save_outputs(tmp_path):
 
     save_ifu_experiment_outputs(outputs, str(tmp_path / "saved"))
     assert (tmp_path / "saved" / "summary.json").exists()
+    assert (tmp_path / "saved" / "run_manifest.json").exists()
     assert (tmp_path / "saved" / "predictive_summary.npz").exists()
     assert (tmp_path / "saved" / "residual_products.npz").exists()
     assert (tmp_path / "saved" / "science_products.npz").exists()
@@ -157,6 +158,7 @@ def test_run_ifu_experiment_and_save_outputs(tmp_path):
     report = generate_ifu_experiment_report(str(tmp_path / "saved"))
     assert "summary" in report
     assert "artifacts" in report
+    assert report["manifest"] is not None
     assert "science_products" in report["artifacts"]
     assert "posterior_mean_cube" in report["artifacts"]["science_products"]
 


### PR DESCRIPTION
## Summary
- add `run_manifest.json` sidecar in `save_ifu_experiment_outputs`
- manifest includes:
  - generation timestamp
  - output directory
  - run metadata snapshot
  - stage status snapshot
  - artifact inventory (kind + keys/rows when applicable)
- include manifest in `generate_ifu_experiment_report`
- extend experiment tests to assert manifest creation and report inclusion
- update inference docs to list `run_manifest.json` as a standard output artifact

## Validation
- pre-commit run on changed files
- python -m compileall on updated module/tests
