### PR TITLE
feat(inference): add small science baseline create/compare workflow

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -397,6 +397,20 @@ For a one-command staged run, use the sequence orchestrator:
      --config rubix/config/inference_experiment_realdata_scaffold.yml \
      --output-root-dir outputs/ifu_sequence
 
+For baseline tracking across small science runs:
+
+.. code-block:: bash
+
+   python scripts/science_run_baseline.py create \
+     --output-dir outputs/ifu_sequence/full \
+     --baseline-path outputs/ifu_baselines/small_run_baseline.json
+
+   python scripts/science_run_baseline.py compare \
+     --output-dir outputs/ifu_sequence/full \
+     --baseline-path outputs/ifu_baselines/small_run_baseline.json \
+     --tolerance mse=1e-4 \
+     --tolerance final_objective=1e-3
+
 Benchmarking Full-IFU Optimization
 ----------------------------------
 

--- a/rubix/inference/__init__.py
+++ b/rubix/inference/__init__.py
@@ -17,6 +17,8 @@ from .checkpoint import (
     save_checkpoint,
 )
 from .experiment import (
+    compare_science_run_to_baseline,
+    create_science_run_baseline,
     generate_ifu_experiment_report,
     normalize_experiment_config,
     run_ifu_experiment,
@@ -103,6 +105,7 @@ __all__ = [
     "build_loss_from_config",
     "build_loss_from_user_config",
     "combine_loss_fns",
+    "compare_science_run_to_baseline",
     "benchmark_callable",
     "benchmark_ifu_cube_optimization",
     "benchmark_result_to_dict",
@@ -136,6 +139,7 @@ __all__ = [
     "summarize_masked_metrics",
     "summarize_predictive_cube_samples",
     "save_checkpoint",
+    "create_science_run_baseline",
     "run_ifu_experiment",
     "run_ifu_experiment_sequence",
     "save_ifu_experiment_outputs",

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1473,3 +1473,89 @@ def run_ifu_experiment_sequence(
         sequence["full"] = full_meta
 
     return sequence
+
+
+def create_science_run_baseline(output_dir: str, baseline_path: str) -> dict[str, Any]:
+    """Create a baseline JSON snapshot from saved run outputs.
+
+    Args:
+        output_dir (str): Directory containing saved run outputs.
+        baseline_path (str): Destination baseline JSON path.
+
+    Returns:
+        dict[str, Any]: Baseline payload written to ``baseline_path``.
+    """
+    report = generate_ifu_experiment_report(output_dir)
+    summary = report.get("summary", {})
+    baseline = {
+        "created_at_utc": _utc_now_iso(),
+        "output_dir": output_dir,
+        "run_metadata": summary.get("run_metadata"),
+        "metrics": summary.get("metrics"),
+        "optimization": summary.get("optimization"),
+        "variational": summary.get("variational"),
+    }
+    path = Path(baseline_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_to_jsonable(baseline), indent=2), encoding="utf-8")
+    return baseline
+
+
+def compare_science_run_to_baseline(
+    output_dir: str,
+    baseline_path: str,
+    tolerances: Optional[Mapping[str, float]] = None,
+) -> dict[str, Any]:
+    """Compare a saved run against a baseline snapshot.
+
+    Args:
+        output_dir (str): Directory containing saved run outputs.
+        baseline_path (str): Baseline JSON produced by
+            :func:`create_science_run_baseline`.
+        tolerances (Optional[Mapping[str, float]], optional): Absolute
+            tolerances by metric/objective key (for example ``mse`` or
+            ``final_objective``). Defaults to ``None`` (zero tolerance).
+
+    Returns:
+        dict[str, Any]: Comparison report with pass/fail and per-key deltas.
+    """
+    report = generate_ifu_experiment_report(output_dir)
+    current_summary = report.get("summary", {})
+    baseline = json.loads(Path(baseline_path).read_text(encoding="utf-8"))
+    tolerances = dict(tolerances or {})
+
+    comparisons: dict[str, Any] = {}
+
+    def compare_section(section: str, keys: list[str]) -> None:
+        current_section = current_summary.get(section) or {}
+        baseline_section = baseline.get(section) or {}
+        for key in keys:
+            if key not in current_section or key not in baseline_section:
+                continue
+            current_value = float(current_section[key])
+            baseline_value = float(baseline_section[key])
+            delta = current_value - baseline_value
+            tol = float(tolerances.get(key, 0.0))
+            comparisons[f"{section}.{key}"] = {
+                "current": current_value,
+                "baseline": baseline_value,
+                "delta": delta,
+                "abs_delta": abs(delta),
+                "tolerance": tol,
+                "passed": abs(delta) <= tol,
+            }
+
+    metric_keys = list((current_summary.get("metrics") or {}).keys())
+    compare_section("metrics", metric_keys)
+    compare_section("optimization", ["final_loss", "best_loss"])
+    compare_section("variational", ["final_objective", "best_objective"])
+
+    passed = (
+        all(item["passed"] for item in comparisons.values()) if comparisons else True
+    )
+    return {
+        "passed": passed,
+        "baseline_path": baseline_path,
+        "output_dir": output_dir,
+        "comparisons": comparisons,
+    }

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1487,10 +1487,19 @@ def create_science_run_baseline(output_dir: str, baseline_path: str) -> dict[str
     """
     report = generate_ifu_experiment_report(output_dir)
     summary = report.get("summary", {})
+
+    run_metadata = summary.get("run_metadata")
+    if run_metadata is None:
+        summary_path = Path(output_dir) / "summary.json"
+        if summary_path.exists():
+            loaded_summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            if isinstance(loaded_summary, dict):
+                run_metadata = loaded_summary.get("run_metadata")
+
     baseline = {
         "created_at_utc": _utc_now_iso(),
         "output_dir": output_dir,
-        "run_metadata": summary.get("run_metadata"),
+        "run_metadata": run_metadata,
         "metrics": summary.get("metrics"),
         "optimization": summary.get("optimization"),
         "variational": summary.get("variational"),

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1585,12 +1585,14 @@ def compare_science_run_to_baseline(
     compare_section("optimization", ["final_loss", "best_loss"])
     compare_section("variational", ["final_objective", "best_objective"])
 
-    passed = (
-        all(item["passed"] for item in comparisons.values()) if comparisons else True
+    compared_keys = len(comparisons)
+    passed = compared_keys > 0 and all(
+        item["passed"] for item in comparisons.values()
     )
     return {
         "passed": passed,
         "baseline_path": baseline_path,
         "output_dir": output_dir,
+        "compared_keys": compared_keys,
         "comparisons": comparisons,
     }

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1586,9 +1586,7 @@ def compare_science_run_to_baseline(
     compare_section("variational", ["final_objective", "best_objective"])
 
     compared_keys = len(comparisons)
-    passed = compared_keys > 0 and all(
-        item["passed"] for item in comparisons.values()
-    )
+    passed = compared_keys > 0 and all(item["passed"] for item in comparisons.values())
     return {
         "passed": passed,
         "baseline_path": baseline_path,

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1532,6 +1532,11 @@ def compare_science_run_to_baseline(
     current_summary = report.get("summary", {})
     baseline = json.loads(Path(baseline_path).read_text(encoding="utf-8"))
     tolerances = dict(tolerances or {})
+    invalid_tolerances = {k: v for k, v in tolerances.items() if v < 0}
+    if invalid_tolerances:
+        raise ValueError(
+            f"All tolerances must be >= 0; got negative values for: {invalid_tolerances}"
+        )
 
     comparisons: dict[str, Any] = {}
 

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1539,22 +1539,48 @@ def compare_science_run_to_baseline(
         current_section = current_summary.get(section) or {}
         baseline_section = baseline.get(section) or {}
         for key in keys:
-            if key not in current_section or key not in baseline_section:
+            current_has_key = key in current_section
+            baseline_has_key = key in baseline_section
+            comparison_key = f"{section}.{key}"
+            if not current_has_key or not baseline_has_key:
+                comparisons[comparison_key] = {
+                    "current": (
+                        float(current_section[key]) if current_has_key else None
+                    ),
+                    "baseline": (
+                        float(baseline_section[key]) if baseline_has_key else None
+                    ),
+                    "delta": None,
+                    "abs_delta": None,
+                    "tolerance": float(tolerances.get(key, 0.0)),
+                    "missing": {
+                        "current": not current_has_key,
+                        "baseline": not baseline_has_key,
+                    },
+                    "passed": False,
+                }
                 continue
             current_value = float(current_section[key])
             baseline_value = float(baseline_section[key])
             delta = current_value - baseline_value
             tol = float(tolerances.get(key, 0.0))
-            comparisons[f"{section}.{key}"] = {
+            comparisons[comparison_key] = {
                 "current": current_value,
                 "baseline": baseline_value,
                 "delta": delta,
                 "abs_delta": abs(delta),
                 "tolerance": tol,
+                "missing": {
+                    "current": False,
+                    "baseline": False,
+                },
                 "passed": abs(delta) <= tol,
             }
 
-    metric_keys = list((current_summary.get("metrics") or {}).keys())
+    metric_keys = list(
+        set((current_summary.get("metrics") or {}).keys())
+        | set((baseline.get("metrics") or {}).keys())
+    )
     compare_section("metrics", metric_keys)
     compare_section("optimization", ["final_loss", "best_loss"])
     compare_section("variational", ["final_objective", "best_objective"])

--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1532,8 +1532,8 @@ def compare_science_run_to_baseline(
     current_summary = report.get("summary", {})
     baseline = json.loads(Path(baseline_path).read_text(encoding="utf-8"))
     tolerances = dict(tolerances or {})
-    invalid_tolerances = {k: v for k, v in tolerances.items() if v < 0}
-    if invalid_tolerances:
+    if any(v < 0 for v in tolerances.values()):
+        invalid_tolerances = {k: v for k, v in tolerances.items() if v < 0}
         raise ValueError(
             f"All tolerances must be >= 0; got negative values for: {invalid_tolerances}"
         )

--- a/scripts/science_run_baseline.py
+++ b/scripts/science_run_baseline.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+import argparse
+import json
+
+from rubix.inference.experiment import (
+    compare_science_run_to_baseline,
+    create_science_run_baseline,
+)
+
+
+def parse_tolerances(items: list[str]) -> dict[str, float]:
+    tolerances: dict[str, float] = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"invalid tolerance '{item}'; expected format key=value")
+        key, value = item.split("=", 1)
+        tolerances[key.strip()] = float(value)
+    return tolerances
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create or compare small-science run baselines."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create_parser = subparsers.add_parser(
+        "create", help="Create baseline snapshot from saved run output."
+    )
+    create_parser.add_argument("--output-dir", required=True, type=str)
+    create_parser.add_argument("--baseline-path", required=True, type=str)
+
+    compare_parser = subparsers.add_parser(
+        "compare", help="Compare saved run output to baseline snapshot."
+    )
+    compare_parser.add_argument("--output-dir", required=True, type=str)
+    compare_parser.add_argument("--baseline-path", required=True, type=str)
+    compare_parser.add_argument(
+        "--tolerance",
+        action="append",
+        default=[],
+        help=(
+            "Tolerance override in key=value format, e.g. --tolerance mse=1e-4 "
+            "--tolerance final_objective=1e-3"
+        ),
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if args.command == "create":
+        baseline = create_science_run_baseline(
+            output_dir=args.output_dir,
+            baseline_path=args.baseline_path,
+        )
+        print(json.dumps(baseline, indent=2))
+        return
+
+    tolerances = parse_tolerances(args.tolerance)
+    result = compare_science_run_to_baseline(
+        output_dir=args.output_dir,
+        baseline_path=args.baseline_path,
+        tolerances=tolerances,
+    )
+    print(json.dumps(result, indent=2))
+    if not result["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -583,7 +583,8 @@ def test_create_and_compare_science_run_baseline(tmp_path):
     )
     assert compare_ok["passed"] is True
 
-    # Perturb baseline metrics to force a comparison failure without negative tolerances
+    # Perturb baseline metrics to force a comparison failure without negative tolerances.
+    # A large offset (999.0) is chosen to exceed any realistic metric tolerance.
     baseline_data = json.loads(baseline_path.read_text())
     metrics = baseline_data.get("metrics") or {}
     if metrics:

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -570,6 +570,9 @@ def test_create_and_compare_science_run_baseline(tmp_path):
     baseline = create_science_run_baseline(str(output_dir), str(baseline_path))
     assert baseline_path.exists()
     assert baseline["metrics"] is not None
+    assert baseline["run_metadata"] is not None
+    assert baseline["run_metadata"]["git_commit_sha"] is not None
+    assert baseline["run_metadata"]["config_hash_sha256"] is not None
 
     compare_ok = compare_science_run_to_baseline(
         output_dir=str(output_dir),

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -10,6 +10,8 @@ from rubix.inference.checkpoint import (
     save_checkpoint,
 )
 from rubix.inference.experiment import (
+    compare_science_run_to_baseline,
+    create_science_run_baseline,
     generate_ifu_experiment_report,
     normalize_experiment_config,
     run_ifu_experiment,
@@ -547,3 +549,38 @@ def test_run_ifu_experiment_sequence_raises_on_failed_validation(tmp_path):
         assert "validation phase failed" in str(exc)
     else:
         raise AssertionError("Expected RuntimeError for failed validation phase")
+
+
+def test_create_and_compare_science_run_baseline(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    config_path = _write_config(tmp_path, str(target_path), str(tmp_path / "ckpt"))
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    outputs = run_ifu_experiment(str(config_path), pipeline_factory=pipeline_factory)
+    output_dir = tmp_path / "saved"
+    save_ifu_experiment_outputs(outputs, str(output_dir))
+
+    baseline_path = tmp_path / "baseline.json"
+    baseline = create_science_run_baseline(str(output_dir), str(baseline_path))
+    assert baseline_path.exists()
+    assert baseline["metrics"] is not None
+
+    compare_ok = compare_science_run_to_baseline(
+        output_dir=str(output_dir),
+        baseline_path=str(baseline_path),
+        tolerances={},
+    )
+    assert compare_ok["passed"] is True
+
+    compare_fail = compare_science_run_to_baseline(
+        output_dir=str(output_dir),
+        baseline_path=str(baseline_path),
+        tolerances={"mse": -1.0},
+    )
+    assert compare_fail["passed"] is False

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -1,7 +1,9 @@
+import json
 from pathlib import Path
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
 import yaml
 
 from rubix.core.data import Galaxy, GasData, RubixData, StarsData
@@ -559,7 +561,7 @@ def test_create_and_compare_science_run_baseline(tmp_path):
     np.save(tmp_path / "ivar.npy", np.ones_like(cube))
     config_path = _write_config(tmp_path, str(target_path), str(tmp_path / "ckpt"))
 
-    def pipeline_factory(_cfg, _mode):
+    def pipeline_factory(_cfg, mode):
         return PreparedSyntheticPipeline(jnp.asarray(cube))
 
     outputs = run_ifu_experiment(str(config_path), pipeline_factory=pipeline_factory)
@@ -581,9 +583,48 @@ def test_create_and_compare_science_run_baseline(tmp_path):
     )
     assert compare_ok["passed"] is True
 
+    # Perturb baseline metrics to force a comparison failure without negative tolerances
+    baseline_data = json.loads(baseline_path.read_text())
+    metrics = baseline_data.get("metrics") or {}
+    if metrics:
+        first_key = next(iter(metrics))
+        baseline_data["metrics"][first_key] = float(metrics[first_key]) + 999.0
+    else:
+        # Fall back to perturbing optimization if metrics are absent
+        opt = baseline_data.get("optimization") or {}
+        if "final_loss" in opt:
+            baseline_data["optimization"]["final_loss"] = float(opt["final_loss"]) + 999.0
+    baseline_path.write_text(json.dumps(baseline_data))
+
     compare_fail = compare_science_run_to_baseline(
         output_dir=str(output_dir),
         baseline_path=str(baseline_path),
-        tolerances={"mse": -1.0},
+        tolerances={},
     )
     assert compare_fail["passed"] is False
+
+
+def test_compare_science_run_to_baseline_negative_tolerance_raises(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    config_path = _write_config(tmp_path, str(target_path), str(tmp_path / "ckpt"))
+
+    def pipeline_factory(_cfg, mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    outputs = run_ifu_experiment(str(config_path), pipeline_factory=pipeline_factory)
+    output_dir = tmp_path / "saved"
+    save_ifu_experiment_outputs(outputs, str(output_dir))
+
+    baseline_path = tmp_path / "baseline.json"
+    create_science_run_baseline(str(output_dir), str(baseline_path))
+
+    with pytest.raises(ValueError, match="tolerances must be >= 0"):
+        compare_science_run_to_baseline(
+            output_dir=str(output_dir),
+            baseline_path=str(baseline_path),
+            tolerances={"mse": -1.0},
+        )


### PR DESCRIPTION
## Summary
- add baseline snapshot API: `create_science_run_baseline(output_dir, baseline_path)`
- add baseline comparison API: `compare_science_run_to_baseline(output_dir, baseline_path, tolerances)`
- add CLI workflow: `scripts/science_run_baseline.py` with `create` and `compare` subcommands
- export baseline APIs from `rubix.inference`
- add tests for baseline create/compare pass/fail behavior
- extend inference workflow docs with baseline tracking command examples

## Validation
- pre-commit run on changed files
- python -m compileall on updated module/tests/scripts
