### PR TITLE
feat(inference): add one-command small science cycle wrapper

### DIFF
--- a/docs/inference_workflows.rst
+++ b/docs/inference_workflows.rst
@@ -411,6 +411,24 @@ For baseline tracking across small science runs:
      --tolerance mse=1e-4 \
      --tolerance final_objective=1e-3
 
+For one-command execution of sequence + baseline operations:
+
+.. code-block:: bash
+
+   python scripts/run_small_science_cycle.py \
+     --config rubix/config/inference_experiment_realdata_scaffold.yml \
+     --output-root-dir outputs/ifu_sequence_run1 \
+     --baseline-path outputs/ifu_baselines/run1.json \
+     --create-baseline
+
+   python scripts/run_small_science_cycle.py \
+     --config rubix/config/inference_experiment_realdata_scaffold.yml \
+     --output-root-dir outputs/ifu_sequence_run2 \
+     --baseline-path outputs/ifu_baselines/run1.json \
+     --compare-baseline \
+     --tolerance mse=1e-4 \
+     --tolerance final_objective=1e-3
+
 Benchmarking Full-IFU Optimization
 ----------------------------------
 

--- a/scripts/run_small_science_cycle.py
+++ b/scripts/run_small_science_cycle.py
@@ -32,9 +32,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-root-dir", required=True, type=str)
     parser.add_argument(
         "--baseline-path",
-        required=True,
+        required=False,
+        default=None,
         type=str,
-        help="Baseline JSON path for create/compare.",
+        help="Baseline JSON path for create/compare. Required when --create-baseline or --compare-baseline is set.",
     )
     parser.add_argument(
         "--create-baseline",
@@ -72,7 +73,11 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    tolerances = parse_tolerances(args.tolerance)
+
+    if (args.create_baseline or args.compare_baseline) and not args.baseline_path:
+        raise SystemExit(
+            "--baseline-path is required when using --create-baseline or --compare-baseline"
+        )
 
     sequence = run_ifu_experiment_sequence(
         config=args.config,
@@ -105,6 +110,7 @@ def main() -> None:
             raise SystemExit(
                 f"baseline file does not exist for comparison: {baseline_path}"
             )
+        tolerances = parse_tolerances(args.tolerance)
         compare_result = compare_science_run_to_baseline(
             output_dir=str(full_output_dir),
             baseline_path=args.baseline_path,

--- a/scripts/run_small_science_cycle.py
+++ b/scripts/run_small_science_cycle.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+import argparse
+import json
+from pathlib import Path
+
+from rubix.inference.experiment import (
+    compare_science_run_to_baseline,
+    create_science_run_baseline,
+    run_ifu_experiment_sequence,
+)
+
+
+def parse_tolerances(items: list[str]) -> dict[str, float]:
+    """Parse CLI tolerances in key=value form."""
+    tolerances: dict[str, float] = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"invalid tolerance '{item}'; expected format key=value")
+        key, value = item.split("=", 1)
+        tolerances[key.strip()] = float(value)
+    return tolerances
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a full small-science cycle: validate->smoke->full, then "
+            "baseline create/compare."
+        )
+    )
+    parser.add_argument("--config", required=True, type=str)
+    parser.add_argument("--output-root-dir", required=True, type=str)
+    parser.add_argument(
+        "--baseline-path",
+        required=True,
+        type=str,
+        help="Baseline JSON path for create/compare.",
+    )
+    parser.add_argument(
+        "--create-baseline",
+        action="store_true",
+        help="Create/update baseline from the produced full run outputs.",
+    )
+    parser.add_argument(
+        "--compare-baseline",
+        action="store_true",
+        help="Compare produced full run against baseline and fail on regression.",
+    )
+    parser.add_argument(
+        "--tolerance",
+        action="append",
+        default=[],
+        help="Tolerance in key=value format, e.g. --tolerance mse=1e-4",
+    )
+    parser.add_argument(
+        "--skip-validate",
+        action="store_true",
+        help="Skip validation phase.",
+    )
+    parser.add_argument(
+        "--skip-smoke",
+        action="store_true",
+        help="Skip smoke phase.",
+    )
+    parser.add_argument(
+        "--skip-full",
+        action="store_true",
+        help="Skip full phase.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    tolerances = parse_tolerances(args.tolerance)
+
+    sequence = run_ifu_experiment_sequence(
+        config=args.config,
+        output_root_dir=args.output_root_dir,
+        run_validate=not args.skip_validate,
+        run_smoke=not args.skip_smoke,
+        run_full=not args.skip_full,
+        include_outputs=False,
+    )
+
+    full_meta = sequence.get("full")
+    full_output_dir = None if full_meta is None else full_meta.get("output_dir")
+
+    baseline_result = None
+    compare_result = None
+
+    if args.create_baseline:
+        if full_output_dir is None:
+            raise SystemExit("cannot create baseline without full phase outputs")
+        baseline_result = create_science_run_baseline(
+            output_dir=str(full_output_dir),
+            baseline_path=args.baseline_path,
+        )
+
+    if args.compare_baseline:
+        if full_output_dir is None:
+            raise SystemExit("cannot compare baseline without full phase outputs")
+        baseline_path = Path(args.baseline_path)
+        if not baseline_path.exists():
+            raise SystemExit(
+                f"baseline file does not exist for comparison: {baseline_path}"
+            )
+        compare_result = compare_science_run_to_baseline(
+            output_dir=str(full_output_dir),
+            baseline_path=args.baseline_path,
+            tolerances=tolerances,
+        )
+        if not compare_result["passed"]:
+            print(json.dumps(compare_result, indent=2))
+            raise SystemExit(1)
+
+    payload = {
+        "sequence": sequence,
+        "baseline_created": baseline_result is not None,
+        "baseline_compared": compare_result is not None,
+        "compare_result": compare_result,
+    }
+    print(json.dumps(payload, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_small_science_cycle.py
+++ b/scripts/run_small_science_cycle.py
@@ -120,13 +120,18 @@ def main() -> None:
             print(json.dumps(compare_result, indent=2))
             raise SystemExit(1)
 
-    payload = {
-        "sequence": sequence,
+    # Print a lightweight, machine-readable summary; detailed per-phase
+    # artifacts (summary.json, validate_report.json, etc.) are on disk.
+    summary = {
+        "output_root_dir": sequence.get("output_root_dir"),
+        "validate_ok": (sequence.get("validate") or {}).get("ok"),
+        "smoke_output_dir": (sequence.get("smoke") or {}).get("output_dir"),
+        "full_output_dir": (sequence.get("full") or {}).get("output_dir"),
         "baseline_created": baseline_result is not None,
         "baseline_compared": compare_result is not None,
-        "compare_result": compare_result,
+        "compare_passed": compare_result["passed"] if compare_result is not None else None,
     }
-    print(json.dumps(payload, indent=2, default=str))
+    print(json.dumps(summary, indent=2))
 
 
 if __name__ == "__main__":

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,103 @@
+"""Shared test helpers for IFU experiment tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import jax.numpy as jnp
+import yaml
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+
+
+class PreparedSyntheticPipeline:
+    """Synthetic pipeline implementing prepare_data + run_sharded."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def prepare_data(self) -> RubixData:
+        return RubixData(
+            galaxy=Galaxy(),
+            stars=StarsData(
+                coords=jnp.zeros((1, 3)),
+                velocity=jnp.zeros((1, 3)),
+                mass=jnp.ones(1),
+                age=jnp.array([0.2]),
+                metallicity=jnp.array([0.01]),
+            ),
+            gas=GasData(
+                coords=jnp.zeros((1, 3)),
+                velocity=jnp.zeros((1, 3)),
+                mass=jnp.ones(1),
+            ),
+        )
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        scale = rubixdata.stars.age[0]
+        return scale * self.template
+
+
+def write_experiment_config(
+    tmp_path: Path,
+    target_path: str,
+    checkpoint_dir: str,
+    *,
+    max_steps: int = 40,
+    checkpoint_interval_steps: int = 20,
+    num_draws: int = 4,
+) -> Path:
+    """Write a minimal experiment YAML config for tests.
+
+    Args:
+        tmp_path: Temporary directory for config and auxiliary files.
+        target_path: Path to the target data ``.npy`` file.
+        checkpoint_dir: Directory where checkpoints will be written.
+        max_steps: Number of steps for both optimization and variational phases.
+        checkpoint_interval_steps: Steps between checkpoint saves (applies to
+            both optimization and variational phases).
+        num_draws: Number of posterior-predictive draws.
+
+    Returns:
+        Path to the written experiment YAML file.
+    """
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+            "seed": 0,
+            "output_dir": str(tmp_path / "outputs"),
+            "checkpoint_dir": checkpoint_dir,
+            "params_init_overrides": {"stars": {"age": [0.2]}},
+        },
+        "data": {
+            "target_path": target_path,
+            "mask_path": str(tmp_path / "mask.npy"),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {
+            "enabled": True,
+            "learning_rate": 0.1,
+            "max_steps": max_steps,
+            "tol": 1e-8,
+            "checkpoint_interval_steps": checkpoint_interval_steps,
+        },
+        "variational": {
+            "enabled": True,
+            "learning_rate": 0.05,
+            "max_steps": max_steps,
+            "tol": 1e-8,
+            "num_samples": 2,
+            "beta_kl": 1e-4,
+            "checkpoint_interval_steps": checkpoint_interval_steps,
+        },
+        "predictive": {
+            "enabled": True,
+            "num_draws": num_draws,
+        },
+    }
+
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
+    config_path = tmp_path / "experiment.yml"
+    config_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return config_path

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -4,9 +4,7 @@ from pathlib import Path
 import jax.numpy as jnp
 import numpy as np
 import pytest
-import yaml
 
-from rubix.core.data import Galaxy, GasData, RubixData, StarsData
 from rubix.inference.checkpoint import (
     make_optimization_checkpoint,
     save_checkpoint,
@@ -23,83 +21,18 @@ from rubix.inference.experiment import (
 )
 from rubix.inference.optimize import OptimizationResult, OptimizationState
 
-
-class PreparedSyntheticPipeline:
-    """Synthetic pipeline implementing prepare_data + run_sharded."""
-
-    def __init__(self, template: jnp.ndarray):
-        self.template = template
-
-    def prepare_data(self) -> RubixData:
-        return RubixData(
-            galaxy=Galaxy(),
-            stars=StarsData(
-                coords=jnp.zeros((1, 3)),
-                velocity=jnp.zeros((1, 3)),
-                mass=jnp.ones(1),
-                age=jnp.array([0.2]),
-                metallicity=jnp.array([0.01]),
-            ),
-            gas=GasData(
-                coords=jnp.zeros((1, 3)),
-                velocity=jnp.zeros((1, 3)),
-                mass=jnp.ones(1),
-            ),
-        )
-
-    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
-        scale = rubixdata.stars.age[0]
-        return scale * self.template
+from tests._helpers import PreparedSyntheticPipeline, write_experiment_config
 
 
 class PreparedNaNPipeline(PreparedSyntheticPipeline):
     """Synthetic pipeline that returns NaNs to force stage failure artifacts."""
 
-    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+    def run_sharded(self, rubixdata) -> jnp.ndarray:
         return jnp.full_like(self.template, jnp.nan)
 
 
 def _write_config(tmp_path: Path, target_path: str, checkpoint_dir: str) -> Path:
-    cfg = {
-        "run": {
-            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
-            "mode": "deterministic",
-            "seed": 0,
-            "output_dir": str(tmp_path / "outputs"),
-            "checkpoint_dir": checkpoint_dir,
-            "params_init_overrides": {"stars": {"age": [0.2]}},
-        },
-        "data": {
-            "target_path": target_path,
-            "mask_path": str(tmp_path / "mask.npy"),
-            "inv_variance_path": str(tmp_path / "ivar.npy"),
-        },
-        "optimization": {
-            "enabled": True,
-            "learning_rate": 0.1,
-            "max_steps": 40,
-            "tol": 1e-8,
-            "checkpoint_interval_steps": 20,
-        },
-        "variational": {
-            "enabled": True,
-            "learning_rate": 0.05,
-            "max_steps": 40,
-            "tol": 1e-8,
-            "num_samples": 2,
-            "beta_kl": 1e-4,
-            "checkpoint_interval_steps": 20,
-        },
-        "predictive": {
-            "enabled": True,
-            "num_draws": 4,
-        },
-    }
-
-    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
-    config_path = tmp_path / "experiment.yml"
-    config_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
-    return config_path
+    return write_experiment_config(tmp_path, target_path, checkpoint_dir)
 
 
 def test_normalize_experiment_config_applies_defaults():

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -594,7 +594,9 @@ def test_create_and_compare_science_run_baseline(tmp_path):
         # Fall back to perturbing optimization if metrics are absent
         opt = baseline_data.get("optimization") or {}
         if "final_loss" in opt:
-            baseline_data["optimization"]["final_loss"] = float(opt["final_loss"]) + 999.0
+            baseline_data["optimization"]["final_loss"] = (
+                float(opt["final_loss"]) + 999.0
+            )
     baseline_path.write_text(json.dumps(baseline_data))
 
     compare_fail = compare_science_run_to_baseline(

--- a/tests/test_small_science_cycle_cli.py
+++ b/tests/test_small_science_cycle_cli.py
@@ -1,85 +1,20 @@
+import json
+import subprocess
+import sys
 from pathlib import Path
 
 import jax.numpy as jnp
 import numpy as np
-import yaml
 
-from rubix.core.data import Galaxy, GasData, RubixData, StarsData
 from rubix.inference.experiment import (
     compare_science_run_to_baseline,
     create_science_run_baseline,
     run_ifu_experiment_sequence,
 )
 
+from tests._helpers import PreparedSyntheticPipeline, write_experiment_config
 
-class PreparedSyntheticPipeline:
-    """Synthetic pipeline for sequence/baseline cycle tests."""
-
-    def __init__(self, template: jnp.ndarray):
-        self.template = template
-
-    def prepare_data(self) -> RubixData:
-        return RubixData(
-            galaxy=Galaxy(),
-            stars=StarsData(
-                coords=jnp.zeros((1, 3)),
-                velocity=jnp.zeros((1, 3)),
-                mass=jnp.ones(1),
-                age=jnp.array([0.2]),
-                metallicity=jnp.array([0.01]),
-            ),
-            gas=GasData(
-                coords=jnp.zeros((1, 3)),
-                velocity=jnp.zeros((1, 3)),
-                mass=jnp.ones(1),
-            ),
-        )
-
-    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
-        return rubixdata.stars.age[0] * self.template
-
-
-def _write_config(tmp_path: Path, target_path: str, checkpoint_dir: str) -> Path:
-    cfg = {
-        "run": {
-            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
-            "mode": "deterministic",
-            "seed": 0,
-            "output_dir": str(tmp_path / "outputs"),
-            "checkpoint_dir": checkpoint_dir,
-            "params_init_overrides": {"stars": {"age": [0.2]}},
-        },
-        "data": {
-            "target_path": target_path,
-            "mask_path": str(tmp_path / "mask.npy"),
-            "inv_variance_path": str(tmp_path / "ivar.npy"),
-        },
-        "optimization": {
-            "enabled": True,
-            "learning_rate": 0.1,
-            "max_steps": 20,
-            "tol": 1e-8,
-            "checkpoint_interval_steps": 10,
-        },
-        "variational": {
-            "enabled": True,
-            "learning_rate": 0.05,
-            "max_steps": 20,
-            "tol": 1e-8,
-            "num_samples": 2,
-            "beta_kl": 1e-4,
-            "checkpoint_interval_steps": 10,
-        },
-        "predictive": {
-            "enabled": True,
-            "num_draws": 3,
-        },
-    }
-
-    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
-    config_path = tmp_path / "experiment.yml"
-    config_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
-    return config_path
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "run_small_science_cycle.py"
 
 
 def test_small_science_cycle_sequence_create_compare(tmp_path):
@@ -88,7 +23,10 @@ def test_small_science_cycle_sequence_create_compare(tmp_path):
     np.save(target_path, cube)
     np.save(tmp_path / "mask.npy", np.ones_like(cube))
     np.save(tmp_path / "ivar.npy", np.ones_like(cube))
-    config_path = _write_config(tmp_path, str(target_path), str(tmp_path / "ckpt"))
+    config_path = write_experiment_config(
+        tmp_path, str(target_path), str(tmp_path / "ckpt"),
+        max_steps=40, checkpoint_interval_steps=20, num_draws=4,
+    )
 
     def pipeline_factory(_cfg, _mode):
         return PreparedSyntheticPipeline(jnp.asarray(cube))
@@ -110,3 +48,58 @@ def test_small_science_cycle_sequence_create_compare(tmp_path):
         tolerances={"mse": 1e-6, "final_objective": 1e-6},
     )
     assert compare_result["passed"] is True
+
+
+def test_cli_missing_baseline_path_exits(tmp_path):
+    """CLI exits with a non-zero code when --create-baseline is given without --baseline-path."""
+    # The guard fires before config loading, so the config file need not exist.
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--config",
+            str(tmp_path / "experiment.yml"),
+            "--output-root-dir",
+            str(tmp_path / "out"),
+            "--create-baseline",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "--baseline-path" in result.stderr
+
+
+def test_cli_sequence_only_exits_0(tmp_path):
+    """CLI exits 0 and prints a JSON summary when all phases are skipped and no baseline ops."""
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    config_path = write_experiment_config(
+        tmp_path, str(target_path), str(tmp_path / "ckpt"),
+        max_steps=40, checkpoint_interval_steps=20, num_draws=4,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--config",
+            str(config_path),
+            "--output-root-dir",
+            str(tmp_path / "out"),
+            "--skip-validate",
+            "--skip-smoke",
+            "--skip-full",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    summary = json.loads(result.stdout)
+    assert "validate_ok" in summary
+    assert "full_output_dir" in summary
+    assert summary["baseline_created"] is False
+    assert summary["baseline_compared"] is False

--- a/tests/test_small_science_cycle_cli.py
+++ b/tests/test_small_science_cycle_cli.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+import yaml
+
+from rubix.core.data import Galaxy, GasData, RubixData, StarsData
+from rubix.inference.experiment import (
+    compare_science_run_to_baseline,
+    create_science_run_baseline,
+    run_ifu_experiment_sequence,
+)
+
+
+class PreparedSyntheticPipeline:
+    """Synthetic pipeline for sequence/baseline cycle tests."""
+
+    def __init__(self, template: jnp.ndarray):
+        self.template = template
+
+    def prepare_data(self) -> RubixData:
+        return RubixData(
+            galaxy=Galaxy(),
+            stars=StarsData(
+                coords=jnp.zeros((1, 3)),
+                velocity=jnp.zeros((1, 3)),
+                mass=jnp.ones(1),
+                age=jnp.array([0.2]),
+                metallicity=jnp.array([0.01]),
+            ),
+            gas=GasData(
+                coords=jnp.zeros((1, 3)),
+                velocity=jnp.zeros((1, 3)),
+                mass=jnp.ones(1),
+            ),
+        )
+
+    def run_sharded(self, rubixdata: RubixData) -> jnp.ndarray:
+        return rubixdata.stars.age[0] * self.template
+
+
+def _write_config(tmp_path: Path, target_path: str, checkpoint_dir: str) -> Path:
+    cfg = {
+        "run": {
+            "rubix_config_path": str(tmp_path / "rubix_user.yml"),
+            "mode": "deterministic",
+            "seed": 0,
+            "output_dir": str(tmp_path / "outputs"),
+            "checkpoint_dir": checkpoint_dir,
+            "params_init_overrides": {"stars": {"age": [0.2]}},
+        },
+        "data": {
+            "target_path": target_path,
+            "mask_path": str(tmp_path / "mask.npy"),
+            "inv_variance_path": str(tmp_path / "ivar.npy"),
+        },
+        "optimization": {
+            "enabled": True,
+            "learning_rate": 0.1,
+            "max_steps": 20,
+            "tol": 1e-8,
+            "checkpoint_interval_steps": 10,
+        },
+        "variational": {
+            "enabled": True,
+            "learning_rate": 0.05,
+            "max_steps": 20,
+            "tol": 1e-8,
+            "num_samples": 2,
+            "beta_kl": 1e-4,
+            "checkpoint_interval_steps": 10,
+        },
+        "predictive": {
+            "enabled": True,
+            "num_draws": 3,
+        },
+    }
+
+    (tmp_path / "rubix_user.yml").write_text("pipeline:\n  name: calc_gradient\n")
+    config_path = tmp_path / "experiment.yml"
+    config_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return config_path
+
+
+def test_small_science_cycle_sequence_create_compare(tmp_path):
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    config_path = _write_config(tmp_path, str(target_path), str(tmp_path / "ckpt"))
+
+    def pipeline_factory(_cfg, _mode):
+        return PreparedSyntheticPipeline(jnp.asarray(cube))
+
+    sequence = run_ifu_experiment_sequence(
+        config=str(config_path),
+        pipeline_factory=pipeline_factory,
+        output_root_dir=str(tmp_path / "sequence"),
+    )
+    full_output_dir = sequence["full"]["output_dir"]
+    baseline_path = tmp_path / "baseline.json"
+
+    create_science_run_baseline(full_output_dir, str(baseline_path))
+    assert baseline_path.exists()
+
+    compare_result = compare_science_run_to_baseline(
+        output_dir=full_output_dir,
+        baseline_path=str(baseline_path),
+        tolerances={"mse": 1e-6, "final_objective": 1e-6},
+    )
+    assert compare_result["passed"] is True


### PR DESCRIPTION
## Summary
- add `scripts/run_small_science_cycle.py` as a one-command wrapper for:
  - sequence run (`validate -> smoke -> full`)
  - baseline creation and/or baseline comparison
- add tolerance parsing for baseline compare pass/fail behavior
- add focused integration-style test `tests/test_small_science_cycle_cli.py`
  covering sequence + baseline create/compare on synthetic data
- document one-command cycle usage in `docs/inference_workflows.rst`

## Validation
- pre-commit run on changed files
- python -m compileall on new script/test
