### PR TITLE
feat(inference): add one-command small science cycle wrapper

### DIFF
--- a/rubix/inference/experiment.py
+++ b/rubix/inference/experiment.py
@@ -1525,6 +1525,10 @@ def compare_science_run_to_baseline(
             tolerances by metric/objective key (for example ``mse`` or
             ``final_objective``). Defaults to ``None`` (zero tolerance).
 
+    Raises:
+        ValueError: If numeric values in compared sections or tolerances cannot
+            be converted to floats.
+
     Returns:
         dict[str, Any]: Comparison report with pass/fail and per-key deltas.
     """

--- a/scripts/run_small_science_cycle.py
+++ b/scripts/run_small_science_cycle.py
@@ -129,7 +129,9 @@ def main() -> None:
         "full_output_dir": (sequence.get("full") or {}).get("output_dir"),
         "baseline_created": baseline_result is not None,
         "baseline_compared": compare_result is not None,
-        "compare_passed": compare_result["passed"] if compare_result is not None else None,
+        "compare_passed": (
+            compare_result["passed"] if compare_result is not None else None
+        ),
     }
     print(json.dumps(summary, indent=2))
 

--- a/scripts/run_small_science_cycle.py
+++ b/scripts/run_small_science_cycle.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import argparse
 import json
+import sys
 from pathlib import Path
 
 from rubix.inference.experiment import (
@@ -79,14 +80,17 @@ def main() -> None:
             "--baseline-path is required when using --create-baseline or --compare-baseline"
         )
 
-    sequence = run_ifu_experiment_sequence(
-        config=args.config,
-        output_root_dir=args.output_root_dir,
-        run_validate=not args.skip_validate,
-        run_smoke=not args.skip_smoke,
-        run_full=not args.skip_full,
-        include_outputs=False,
-    )
+    try:
+        sequence = run_ifu_experiment_sequence(
+            config=args.config,
+            output_root_dir=args.output_root_dir,
+            run_validate=not args.skip_validate,
+            run_smoke=not args.skip_smoke,
+            run_full=not args.skip_full,
+            include_outputs=False,
+        )
+    except RuntimeError as exc:
+        raise SystemExit(str(exc))
 
     full_meta = sequence.get("full")
     full_output_dir = None if full_meta is None else full_meta.get("output_dir")
@@ -98,7 +102,7 @@ def main() -> None:
         if full_output_dir is None:
             raise SystemExit("cannot create baseline without full phase outputs")
         baseline_result = create_science_run_baseline(
-            output_dir=str(full_output_dir),
+            output_dir=full_output_dir,
             baseline_path=args.baseline_path,
         )
 
@@ -112,12 +116,12 @@ def main() -> None:
             )
         tolerances = parse_tolerances(args.tolerance)
         compare_result = compare_science_run_to_baseline(
-            output_dir=str(full_output_dir),
+            output_dir=full_output_dir,
             baseline_path=args.baseline_path,
             tolerances=tolerances,
         )
         if not compare_result["passed"]:
-            print(json.dumps(compare_result, indent=2))
+            print(json.dumps(compare_result, indent=2), file=sys.stderr)
             raise SystemExit(1)
 
     # Print a lightweight, machine-readable summary; detailed per-phase

--- a/tests/test_inference_experiment.py
+++ b/tests/test_inference_experiment.py
@@ -20,7 +20,6 @@ from rubix.inference.experiment import (
     validate_ifu_experiment_inputs,
 )
 from rubix.inference.optimize import OptimizationResult, OptimizationState
-
 from tests._helpers import PreparedSyntheticPipeline, write_experiment_config
 
 

--- a/tests/test_small_science_cycle_cli.py
+++ b/tests/test_small_science_cycle_cli.py
@@ -16,7 +16,14 @@ from tests._helpers import PreparedSyntheticPipeline, write_experiment_config
 _SCRIPT = Path(__file__).parent.parent / "scripts" / "run_small_science_cycle.py"
 
 
-def test_small_science_cycle_sequence_create_compare(tmp_path):
+def test_sequence_create_compare_api(tmp_path):
+    """Python-API-level test: sequence → create baseline → compare baseline.
+
+    This exercises the Python API directly (not the CLI subprocess) because
+    the CLI script uses the default ``make_inference_pipeline`` factory, which
+    requires a full rubix pipeline and cannot be replaced with a synthetic
+    pipeline via command-line arguments alone.
+    """
     cube = np.ones((2, 2, 4), dtype=np.float32)
     target_path = tmp_path / "target.npy"
     np.save(target_path, cube)
@@ -71,6 +78,48 @@ def test_cli_missing_baseline_path_exits(tmp_path):
     )
     assert result.returncode != 0
     assert "--baseline-path" in result.stderr
+
+
+def test_cli_validation_failure_exits_cleanly(tmp_path):
+    """CLI exits with a clean error message (no Python traceback) when validation fails.
+
+    Removing rubix_user.yml causes pipeline setup to fail inside
+    validate_ifu_experiment_inputs, which returns ok=False.  The sequence
+    raises RuntimeError, which the CLI now converts to a clean SystemExit
+    rather than letting the traceback propagate to the terminal.
+    """
+    cube = np.ones((2, 2, 4), dtype=np.float32)
+    target_path = tmp_path / "target.npy"
+    np.save(target_path, cube)
+    np.save(tmp_path / "mask.npy", np.ones_like(cube))
+    np.save(tmp_path / "ivar.npy", np.ones_like(cube))
+    config_path = write_experiment_config(
+        tmp_path,
+        str(target_path),
+        str(tmp_path / "ckpt"),
+        max_steps=1,
+        checkpoint_interval_steps=1,
+        num_draws=1,
+    )
+    # Remove the rubix user config so the pipeline factory raises an error,
+    # causing validation to return ok=False and the sequence to raise RuntimeError.
+    (tmp_path / "rubix_user.yml").unlink()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            "--config",
+            str(config_path),
+            "--output-root-dir",
+            str(tmp_path / "out"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Traceback" not in result.stderr
+    assert "validation" in result.stderr.lower()
 
 
 def test_cli_sequence_only_exits_0(tmp_path):

--- a/tests/test_small_science_cycle_cli.py
+++ b/tests/test_small_science_cycle_cli.py
@@ -11,7 +11,6 @@ from rubix.inference.experiment import (
     create_science_run_baseline,
     run_ifu_experiment_sequence,
 )
-
 from tests._helpers import PreparedSyntheticPipeline, write_experiment_config
 
 _SCRIPT = Path(__file__).parent.parent / "scripts" / "run_small_science_cycle.py"
@@ -24,8 +23,12 @@ def test_small_science_cycle_sequence_create_compare(tmp_path):
     np.save(tmp_path / "mask.npy", np.ones_like(cube))
     np.save(tmp_path / "ivar.npy", np.ones_like(cube))
     config_path = write_experiment_config(
-        tmp_path, str(target_path), str(tmp_path / "ckpt"),
-        max_steps=40, checkpoint_interval_steps=20, num_draws=4,
+        tmp_path,
+        str(target_path),
+        str(tmp_path / "ckpt"),
+        max_steps=40,
+        checkpoint_interval_steps=20,
+        num_draws=4,
     )
 
     def pipeline_factory(_cfg, _mode):
@@ -78,8 +81,12 @@ def test_cli_sequence_only_exits_0(tmp_path):
     np.save(tmp_path / "mask.npy", np.ones_like(cube))
     np.save(tmp_path / "ivar.npy", np.ones_like(cube))
     config_path = write_experiment_config(
-        tmp_path, str(target_path), str(tmp_path / "ckpt"),
-        max_steps=40, checkpoint_interval_steps=20, num_draws=4,
+        tmp_path,
+        str(target_path),
+        str(tmp_path / "ckpt"),
+        max_steps=40,
+        checkpoint_interval_steps=20,
+        num_draws=4,
     )
 
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- add `scripts/run_small_science_cycle.py` as a one-command wrapper for:
  - sequence run (`validate -> smoke -> full`)
  - baseline creation and/or baseline comparison
- add tolerance parsing for baseline compare pass/fail behavior
- add focused integration-style test `tests/test_small_science_cycle_cli.py`
  covering sequence + baseline create/compare on synthetic data
- document one-command cycle usage in `docs/inference_workflows.rst`

## Validation
- pre-commit run on changed files
- python -m compileall on new script/test
